### PR TITLE
Bug/#22 delete nested model does not follow expected window path

### DIFF
--- a/src/Totem/ClientApp/features/contracts/AddModelModalWindow.vue
+++ b/src/Totem/ClientApp/features/contracts/AddModelModalWindow.vue
@@ -166,7 +166,19 @@ export default {
 
     deleteModel() {
       const model = deepCopy(last(this.editStack));
-      this.$emit('delete', model);
+      if (this.editStack.length - 1 > 0) {
+        const parent = this.editStack[this.editStack.length - 2];
+        parent.properties = parent.properties.filter((prop) => {
+          return prop.rowId !== model.rowId;
+        });
+        this.modalFieldName = parent.name;
+        this.editStack.pop();
+        this.$parent.currentIndex -= 1;
+        this.objectRows = deepCopy(parent.properties);
+        this.$parent.modalRows = deepCopy(parent.properties);
+      } else {
+        this.$emit('delete', model);
+      }
     },
 
     close() {

--- a/src/Totem/ClientApp/features/contracts/AddModelModalWindow.vue
+++ b/src/Totem/ClientApp/features/contracts/AddModelModalWindow.vue
@@ -168,7 +168,7 @@ export default {
       const model = deepCopy(last(this.editStack));
       if (this.editStack.length - 1 > 0) {
         const parent = this.editStack[this.editStack.length - 2];
-        parent.properties = parent.properties.filter((prop) => {
+        parent.properties = parent.properties.filter(prop => {
           return prop.rowId !== model.rowId;
         });
         this.modalFieldName = parent.name;

--- a/src/Totem/ClientApp/features/contracts/__tests__/dataHelpers.spec.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/dataHelpers.spec.js
@@ -3,7 +3,9 @@ import {
   getDisplayType,
   deepCopy,
   findRowInTreeAndUpdate,
-  last
+  last,
+  findRowInTreeAndDelete,
+  findParent
 } from '../dataHelpers';
 
 describe('Reorder Options', () => {
@@ -118,6 +120,83 @@ describe('findRowInTreeAndUpdate', () => {
 
     const updatedObject = findRowInTreeAndUpdate(originalTrees, newObject);
     expect(updatedObject[1].properties[1].properties[0].name).toBe('newRow10');
+  });
+});
+
+describe('findRowInTreeAndDelete', () => {
+  it('returns undefined if the rowId is not found anywhere in the tree', () => {
+    const originalTree = [{ rowId: 1, name: 'row1', properties: [{ rowId: 2, name: 'row2' }] }];
+    const objectToDelete = { rowId: 3, name: 'row3' };
+
+    const updatedTree = findRowInTreeAndDelete(originalTree, objectToDelete);
+    expect(updatedTree).toBe(undefined);
+  });
+
+  it('returns a modified tree if the rowId is found anywhere in the tree', () => {
+    const originalTree = [
+      {
+        rowId: 1,
+        name: 'row1',
+        properties: [
+          { rowId: 2, name: 'row2', properties: [{ rowId: 4, name: 'row4' }] },
+          { rowId: 5, name: 'row5', properties: [{ rowId: 3, name: 'row3' }] }
+        ]
+      },
+      {
+        rowId: 6,
+        name: 'row6',
+        properties: [
+          { rowId: 7, name: 'row7', properties: [{ rowId: 8, name: 'row8' }] },
+          {
+            rowId: 9,
+            name: 'row9',
+            properties: [{ rowId: 10, name: 'row10' }, { rowId: 11, name: 'row11' }]
+          }
+        ]
+      }
+    ];
+    const objectToDelete = { rowId: 10, name: 'row10' };
+
+    const updatedTree = findRowInTreeAndDelete(originalTree, objectToDelete);
+    expect(updatedTree[1].properties[1].properties.length).toBe(1);
+    expect(updatedTree[1].properties[1].properties[0].name).toBe('row11');
+  });
+});
+
+describe('findParent', () => {
+  const tree = [
+    {
+      rowId: 1,
+      name: 'row1',
+      properties: [
+        { rowId: 2, name: 'row2', properties: [{ rowId: 4, name: 'row4' }] },
+        { rowId: 5, name: 'row5', properties: [{ rowId: 3, name: 'row3' }] }
+      ]
+    },
+    {
+      rowId: 6,
+      name: 'row6',
+      properties: [
+        { rowId: 7, name: 'row7', properties: [{ rowId: 8, name: 'row8' }] },
+        {
+          rowId: 9,
+          name: 'row9',
+          properties: [{ rowId: 10, name: 'row10' }, { rowId: 11, name: 'row11' }]
+        }
+      ]
+    }
+  ];
+
+  it('returns the parent of the the given child row in a tree', () => {
+    const childRow = { rowId: 11, name: 'row11' };
+    const parentRow = findParent(tree, childRow);
+    expect(parentRow.name).toBe('row9');
+  });
+
+  it('returns null if the child row is a root grid property (top level of nesting)', () => {
+    const childRow = { rowId: 1, name: 'row1' };
+    const parentRow = findParent(tree, childRow);
+    expect(parentRow).toBe(null);
   });
 });
 

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
@@ -429,7 +429,7 @@ test('Cancel edits on a field in the parent model', async t => {
 
 test('Delete a nested model (from the parent model)', async t => {
   await addNewNestedModelAtRoot(t);
-  // To prevent avoid having zero rows in the parent model after deletion
+  // To prevent having zero rows in the parent model after deletion
   await addNewFieldsToParentModel(t);
   // Save the container model
   await t.click(utils.saveModelBtn);
@@ -472,7 +472,7 @@ test('Delete a nested model (from the parent model)', async t => {
 
 test('Edit a nested field after deleting a nested model (from the parent model)', async t => {
   await addNewNestedModelAtRoot(t);
-  // To prevent avoid having zero rows in the parent model after deletion
+  // To prevent having zero rows in the parent model after deletion
   await addNewFieldsToParentModel(t);
   // Save the container model
   await t.click(utils.saveModelBtn);

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
@@ -57,6 +57,21 @@ async function addNewFieldsToNestedModel(t) {
   await t.click(utils.saveFieldBtn);
 }
 
+async function addNewFieldsToParentModel(t) {
+  const rowToEdit = Selector('tr.treegrid-body-row').withText('testModel');
+  const editFieldBtn = rowToEdit.find('.edit-action');
+  await t.click(editFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('testModel');
+
+  await t.click(utils.addNewFieldNestedBtn);
+
+  await t.typeText(utils.inputFieldName, 'newTestProperty', { replace: true });
+  await t.click(utils.inputType).click(Selector('li').withText('DateTime'));
+
+  await t.click(utils.saveFieldBtn);
+}
+
 test('Add a new nested model at the root', async t => {
   const initialRowCount = await Selector('tr.treegrid-body-row').count;
 
@@ -414,6 +429,11 @@ test('Cancel edits on a field in the parent model', async t => {
 
 test('Delete a nested model (from the parent model)', async t => {
   await addNewNestedModelAtRoot(t);
+  // To prevent avoid having zero rows in the parent model after deletion
+  await addNewFieldsToParentModel(t);
+  // Save the container model
+  await t.click(utils.saveModelBtn);
+
   const initialRowCount = await Selector('tr.treegrid-body-row').count;
 
   const rowToEdit = Selector('tr.treegrid-body-row').withText('testModel');
@@ -432,6 +452,11 @@ test('Delete a nested model (from the parent model)', async t => {
 
   const deleteModelBtn = Selector('#modelModalWindow').find('#deleteModelBtn');
   await t.click(deleteModelBtn);
+
+  await t.expect(utils.modelName.value).eql('testModel');
+  await t.expect(nestedModelRowToEdit.exists).eql(false);
+
+  await t.click(utils.saveModelBtn);
 
   const containerModel = Selector('tr.treegrid-body-row').withText('testModel');
   const nestedModelRow = Selector('tr.treegrid-body-row').withText('nestedModel');

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
@@ -470,6 +470,74 @@ test('Delete a nested model (from the parent model)', async t => {
     .eql(false);
 });
 
+test('Edit a nested field after deleting a nested model (from the parent model)', async t => {
+  await addNewNestedModelAtRoot(t);
+  // To prevent avoid having zero rows in the parent model after deletion
+  await addNewFieldsToParentModel(t);
+  // Save the container model
+  await t.click(utils.saveModelBtn);
+
+  const initialRowCount = await Selector('tr.treegrid-body-row').count;
+
+  const rowToEdit = Selector('tr.treegrid-body-row').withText('testModel');
+  const editFieldBtn = rowToEdit.find('.edit-action');
+  await t.click(editFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('testModel');
+
+  const nestedModelRowToEdit = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('nestedModel');
+  const nestedModelEditFieldBtn = nestedModelRowToEdit.find('.edit-action');
+  await t.click(nestedModelEditFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('nestedModel');
+
+  const deleteModelBtn = Selector('#modelModalWindow').find('#deleteModelBtn');
+  await t.click(deleteModelBtn);
+
+  await t.expect(utils.modelName.value).eql('testModel');
+  await t.expect(nestedModelRowToEdit.exists).eql(false);
+
+  await t.click(utils.saveModelBtn);
+
+  const containerModel = Selector('tr.treegrid-body-row').withText('testModel');
+  const nestedModelRow = Selector('tr.treegrid-body-row').withText('nestedModel');
+
+  await t
+    .expect(Selector('tr.treegrid-body-row').count)
+    .eql(initialRowCount - 2)
+    .expect(containerModel.exists)
+    .eql(true)
+    .expect(nestedModelRow.exists)
+    .eql(false);
+
+  // Edit from parent model
+  await t.click(editFieldBtn);
+  const nestedFieldToEdit = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('newTestProperty');
+  const nestedFieldEditBtn = nestedFieldToEdit.find('.edit-action');
+  await t.click(nestedFieldEditBtn);
+
+  await t.expect(utils.inputFieldName.value).eql('newTestProperty');
+  await t.expect(utils.inputFieldExample.value).eql('2019-01-01T18:14:29Z');
+  await t.expect(utils.inputType.getVue(({ props }) => props.value.displayName)).eql('DateTime');
+
+  await t.click(utils.cancelFieldBtn);
+
+  await t.click(utils.cancelModelBtn);
+
+  // Edit from root grid
+  const rootFieldToEdit = Selector('tr.treegrid-body-row').withText('newTestProperty');
+  const rootFieldEditBtn = rootFieldToEdit.find('.edit-action');
+  await t.click(rootFieldEditBtn);
+
+  await t.expect(utils.inputFieldName.value).eql('newTestProperty');
+  await t.expect(utils.inputFieldExample.value).eql('2019-01-01T18:14:29Z');
+  await t.expect(utils.inputType.getVue(({ props }) => props.value.displayName)).eql('DateTime');
+});
+
 test('Delete a nested field (from the parent model)', async t => {
   await addNewNestedModelAtRoot(t);
   await addNewFieldsToNestedModel(t);

--- a/src/Totem/ClientApp/features/contracts/dataHelpers.js
+++ b/src/Totem/ClientApp/features/contracts/dataHelpers.js
@@ -54,4 +54,40 @@ export const findRowInTreeAndUpdate = (tree, updatedModel) => {
   return rowUpdated ? updatedTree : undefined;
 };
 
+export const findRowInTreeAndDelete = (tree, rowToDelete) => {
+  let rowDeleted = false;
+
+  function searchAndDelete(row) {
+    if (
+      Array.isArray(row.properties) &&
+      row.properties.some(prop => prop.rowId === rowToDelete.rowId)
+    ) {
+      // eslint-disable-next-line no-param-reassign
+      row.properties = row.properties.filter(prop => {
+        return prop.rowId !== rowToDelete.rowId;
+      });
+      rowDeleted = true;
+      return true;
+    }
+    return Array.isArray(row.properties) && row.properties.forEach(searchAndDelete);
+  }
+
+  tree.forEach(searchAndDelete);
+  return rowDeleted ? tree : undefined;
+};
+
+export const findParent = (tree, childRow) => {
+  const childRowId = childRow.rowId;
+  let parentRow = null;
+
+  function containsChild(row) {
+    if (Array.isArray(row.properties) && row.properties.some(prop => prop.rowId === childRowId)) {
+      parentRow = deepCopy(row);
+    }
+    return Array.isArray(row.properties) && row.properties.forEach(containsChild);
+  }
+  tree.forEach(containsChild);
+  return parentRow;
+};
+
 export const last = array => array[array.length - 1];


### PR DESCRIPTION
- Updated the 'Delete a nested model (from the parent model)' e2e test to check for the parent ANM window after deletion. Also added a utility function to add a new field to the parent model to avoid having zero rows after deletion from the parent model.
- Refactored the delete method on ANM to handle the case of going back tot he parent model when deleting a nested model.

‌