### PR TITLE
Bug/#28 example field is disabled after editing an object

### DIFF
--- a/src/Totem/ClientApp/App.vue
+++ b/src/Totem/ClientApp/App.vue
@@ -289,7 +289,8 @@ export default {
               id: this.options.length,
               schemaName: field.name,
               schemaString: createSchemaString(field)
-            }
+            },
+            isObject: true
           });
           this.options = reorderOptions(this.options);
         }
@@ -316,7 +317,8 @@ export default {
             id: this.options.length,
             schemaName: updatedModel.name,
             schemaString: createSchemaString(updatedModel)
-          }
+          },
+          isObject: true
         });
         this.options = reorderOptions(this.options);
       } else {

--- a/src/Totem/ClientApp/features/contracts/AddNewFieldModalWindow.vue
+++ b/src/Totem/ClientApp/features/contracts/AddNewFieldModalWindow.vue
@@ -163,6 +163,8 @@ export default {
           };
           this.modalTitle = 'Update Field';
         }
+      } else {
+        this.updateExampleState(currentField.example, false);
       }
       $('.field-name')[0].focus();
     },

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/RootLevelModelField.e2e.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/RootLevelModelField.e2e.js
@@ -172,6 +172,7 @@ test('Add a new model using previous model', async t => {
   // Add a new field based on previous model
   await t.typeText(utils.inputFieldName, 'testNewModel');
   await t.click(utils.inputType).click(Selector('li').withText('testModel'));
+  await t.expect(utils.inputFieldExample.hasAttribute('disabled')).ok();
 
   await t.click(utils.saveFieldBtn);
 


### PR DESCRIPTION
- Added isObject to all the places where an object option was added to the options list. Added an else clause to reset the example field when new fields are being added.
- Updated the 'Add a new model using previous model' e2e test to check that the example field is disabled.