### PR TITLE
Bug/#36 edited models do not update the options object

### DIFF
--- a/src/Totem/ClientApp/App.vue
+++ b/src/Totem/ClientApp/App.vue
@@ -296,6 +296,16 @@ export default {
           this.options = reorderOptions(this.options);
         }
 
+        const parent = findParent(this.rows, field);
+        if (parent) {
+            parent.properties[parent.properties.findIndex(prop => prop.rowId === field.rowId)] = deepCopy(field);
+            const parentOption = this.options.find(option => option.displayName === parent.name);
+            parentOption.displayName = parent.name;
+            parentOption.value.schemaName = parent.name;
+            parentOption.value.schemaString = createSchemaString(parent);
+            this.options = reorderOptions(this.options);
+        }
+
         this.modifiedContract = updateContractString(field, this.rows, this.modifiedContract);
         $('#contract-raw')[0].value = JSON.stringify(JSON.parse(this.modifiedContract), null, 2);
         $('#ModifiedContract_ContractString')[0].value = this.modifiedContract;

--- a/src/Totem/ClientApp/App.vue
+++ b/src/Totem/ClientApp/App.vue
@@ -325,6 +325,8 @@ export default {
         const existingOption = this.options.find(option => option.displayName === model.name);
         if (existingOption) {
           existingOption.displayName = updatedModel.name;
+          existingOption.value.schemaName = updatedModel.name;
+          existingOption.value.schemaString = createSchemaString(updatedModel);
           this.options = reorderOptions(this.options);
         }
       }

--- a/src/Totem/ClientApp/App.vue
+++ b/src/Totem/ClientApp/App.vue
@@ -66,7 +66,8 @@ import {
   deepCopy,
   getUniqueId,
   findRowInTreeAndUpdate,
-  last
+  last,
+  findParent
 } from './features/contracts/dataHelpers';
 
 export default {
@@ -323,12 +324,21 @@ export default {
         this.options = reorderOptions(this.options);
       } else {
         const existingOption = this.options.find(option => option.displayName === model.name);
+        const parent = findParent(this.rows, updatedModel);
+
         if (existingOption) {
           existingOption.displayName = updatedModel.name;
           existingOption.value.schemaName = updatedModel.name;
           existingOption.value.schemaString = createSchemaString(updatedModel);
-          this.options = reorderOptions(this.options);
         }
+        if (parent) {
+            parent.properties[parent.properties.findIndex(prop => prop.rowId === updatedModel.rowId)] = deepCopy(updatedModel);
+            const parentOption = this.options.find(option => option.displayName === parent.name);
+            parentOption.displayName = parent.name;
+            parentOption.value.schemaName = parent.name;
+            parentOption.value.schemaString = createSchemaString(parent);
+        }
+        this.options = reorderOptions(this.options);
       }
       this.editStack.pop();
 

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
@@ -925,3 +925,78 @@ test('Edit a child model of a prior nested model and add a new model using the p
     .expect(editedNestedModelRows.count)
     .eql(2);
 });
+
+test('Edit a primitive child field of a prior nested model and add a new model using the prior nested model with the child edits', async t => {
+  await addNewNestedModelAtRoot(t);
+  await addNewFieldsToParentModel(t);
+  // Save the container model
+  await t.click(utils.saveModelBtn);
+  const initialRowCount = await Selector('tr.treegrid-body-row').count;
+  // Add a new field based on previous model
+  await t.click(utils.addNewFieldBtn);
+
+  await t.typeText(utils.inputFieldName, 'testSecondModel');
+  await t.click(utils.inputType).click(Selector('li').withText('testModel'));
+  await t.expect(utils.inputFieldExample.hasAttribute('disabled')).ok();
+
+  await t.click(utils.saveFieldBtn);
+
+  // Edit the primitive nested field of the original model from the root and save
+  const objectRowToEdit = Selector('tr.treegrid-body-row').withText('newTestProperty');
+  const editFieldBtn = objectRowToEdit.find('.edit-action');
+  await t.click(editFieldBtn);
+
+  await t.expect(utils.inputFieldName.value).eql('newTestProperty');
+  await t.expect(utils.inputFieldExample.value).eql('2019-01-01T18:14:29Z');
+  await t.expect(utils.inputType.getVue(({ props }) => props.value.displayName)).eql('DateTime');
+
+  await t.typeText(utils.inputFieldName, 'editedNewTestProperty', { replace: true });
+  await t.click(utils.inputType).click(Selector('li').withText('Integer'));
+
+  await t.click(utils.saveFieldBtn);
+
+  // Add a third field based on the previous model
+  await t.click(utils.addNewFieldBtn);
+
+  await t.typeText(utils.inputFieldName, 'testThirdModel');
+  await t.click(utils.inputType).click(Selector('li').withText('testModel'));
+  await t.expect(utils.inputFieldExample.hasAttribute('disabled')).ok();
+
+  await t.click(utils.saveFieldBtn);
+
+  const testModelField = Selector('tr.treegrid-body-row').withText('testModel');
+  const testSecondModelField = Selector('tr.treegrid-body-row').withText('testSecondModel');
+  const testThirdModelField = Selector('tr.treegrid-body-row').withText('testThirdModel');
+  const nestedRows = await Selector('tr.treegrid-body-row').withText('testProperty');
+  const nestedModelRows = await Selector('tr.treegrid-body-row').withText('nestedModel');
+  const newTestPropertyRows = await Selector('tr.treegrid-body-row').withText('newTestProperty');
+  const editedNewTestPropertyRows = await Selector('tr.treegrid-body-row').withText(
+    'editedNewTestProperty'
+  );
+
+  await t
+    .expect(Selector('tr.treegrid-body-row').count)
+    .eql(initialRowCount + 8)
+    .expect(testModelField.exists)
+    .eql(true)
+    .expect(testSecondModelField.exists)
+    .eql(true)
+    .expect(testThirdModelField.exists)
+    .eql(true)
+    .expect(nestedRows.exists)
+    .eql(true)
+    .expect(nestedRows.count)
+    .eql(3)
+    .expect(nestedModelRows.exists)
+    .eql(true)
+    .expect(nestedModelRows.count)
+    .eql(3)
+    .expect(newTestPropertyRows.exists)
+    .eql(true)
+    .expect(newTestPropertyRows.count)
+    .eql(1)
+    .expect(editedNewTestPropertyRows.exists)
+    .eql(true)
+    .expect(editedNewTestPropertyRows.count)
+    .eql(2);
+});

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
@@ -863,3 +863,65 @@ test('Change the type of a child field to a model', async t => {
     .expect(new3xNestedPropertyRow.exists)
     .eql(true);
 });
+
+test('Edit a child model of a prior nested model and add a new model using the prior nested model with the child edits', async t => {
+  await addNewNestedModelAtRoot(t);
+  const initialRowCount = await Selector('tr.treegrid-body-row').count;
+  // Add a new field based on previous model
+  await t.click(utils.addNewFieldBtn);
+
+  await t.typeText(utils.inputFieldName, 'testSecondModel');
+  await t.click(utils.inputType).click(Selector('li').withText('testModel'));
+  await t.expect(utils.inputFieldExample.hasAttribute('disabled')).ok();
+
+  await t.click(utils.saveFieldBtn);
+
+  // Edit the nested field of the original model from the root and save
+  const objectRowToEdit = Selector('tr.treegrid-body-row').withText('nestedModel');
+  const editFieldBtn = objectRowToEdit.find('.edit-action');
+  await t.click(editFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('nestedModel');
+  await t.typeText(utils.modelName, 'editedNestedModel', { replace: true });
+  await t.click(utils.saveModelBtn);
+
+  // Add a third field based on the previous model
+  await t.click(utils.addNewFieldBtn);
+
+  await t.typeText(utils.inputFieldName, 'testThirdModel');
+  await t.click(utils.inputType).click(Selector('li').withText('testModel'));
+  await t.expect(utils.inputFieldExample.hasAttribute('disabled')).ok();
+
+  await t.click(utils.saveFieldBtn);
+
+  const testModelField = Selector('tr.treegrid-body-row').withText('testModel');
+  const testSecondModelField = Selector('tr.treegrid-body-row').withText('testSecondModel');
+  const testThirdModelField = Selector('tr.treegrid-body-row').withText('testThirdModel');
+  const nestedRows = await Selector('tr.treegrid-body-row').withText('testProperty');
+  const nestedModelRows = await Selector('tr.treegrid-body-row').withText('nestedModel');
+  const editedNestedModelRows = await Selector('tr.treegrid-body-row').withText(
+    'editedNestedModel'
+  );
+
+  await t
+    .expect(Selector('tr.treegrid-body-row').count)
+    .eql(initialRowCount + 6)
+    .expect(testModelField.exists)
+    .eql(true)
+    .expect(testSecondModelField.exists)
+    .eql(true)
+    .expect(testThirdModelField.exists)
+    .eql(true)
+    .expect(nestedRows.exists)
+    .eql(true)
+    .expect(nestedRows.count)
+    .eql(3)
+    .expect(nestedModelRows.exists)
+    .eql(true)
+    .expect(nestedModelRows.count)
+    .eql(1)
+    .expect(editedNestedModelRows.exists)
+    .eql(true)
+    .expect(editedNestedModelRows.count)
+    .eql(2);
+});

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/RootLevelModelField.e2e.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/RootLevelModelField.e2e.js
@@ -189,6 +189,53 @@ test('Add a new model using previous model', async t => {
     .eql(2);
 });
 
+test('Edit a previous model and add a new model using the previous model with the edits', async t => {
+  await addNewModelAtRoot(t);
+  // Add a new field to the model and save
+  const objectRowToEdit = Selector('tr.treegrid-body-row').withText('testModel');
+  const editFieldBtn = objectRowToEdit.find('.edit-action');
+  await t.click(editFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('testModel');
+
+  await t.click(utils.addNewFieldNestedBtn);
+
+  await t.typeText(utils.inputFieldName, 'newTestModelProperty');
+  await t.click(utils.inputType).click(Selector('li').withText('DateTime'));
+
+  await t.click(utils.saveFieldBtn);
+
+  await t.click(utils.saveModelBtn);
+
+  const initialRowCount = await Selector('tr.treegrid-body-row').count;
+
+  // Add a new field based on previous model
+  await t.click(utils.addNewFieldBtn);
+
+  await t.typeText(utils.inputFieldName, 'testNewModel');
+  await t.click(utils.inputType).click(Selector('li').withText('testModel'));
+  await t.expect(utils.inputFieldExample.hasAttribute('disabled')).ok();
+
+  await t.click(utils.saveFieldBtn);
+
+  const newlyAddedModelField = Selector('tr.treegrid-body-row').withText('testNewModel');
+  const nestedRows = await Selector('tr.treegrid-body-row').withText('testProperty');
+  const newTestModelRows = await Selector('tr.treegrid-body-row').withText('newTestModelProperty');
+  await t
+    .expect(Selector('tr.treegrid-body-row').count)
+    .eql(initialRowCount + 3)
+    .expect(newlyAddedModelField.exists)
+    .eql(true)
+    .expect(nestedRows.exists)
+    .eql(true)
+    .expect(nestedRows.count)
+    .eql(2)
+    .expect(newTestModelRows.exists)
+    .eql(true)
+    .expect(newTestModelRows.count)
+    .eql(2);
+});
+
 test('Edit a non-root level field from the root table', async t => {
   await addNewModelAtRoot(t);
   const initialRowCount = await Selector('tr.treegrid-body-row').count;


### PR DESCRIPTION
- Added an e2e test to check  whether editing the previously defined model  and then creating a new model based on the previous model has the new edits.
- Refactored to update the option schemaString and schemaName when the defined model is changed.
