### PR TITLE
#21 allow testing a subset of a contract

### DIFF
--- a/src/Totem.Tests/Features/API/TestMessageTests.cs
+++ b/src/Totem.Tests/Features/API/TestMessageTests.cs
@@ -487,5 +487,47 @@ namespace Totem.Tests.Features.API
                 "The schema for \"FirstName\" was not found in the contract definition."
             });
         }
+
+        public async Task ShouldBeValidWhenMessageMatchesSubsetContract()
+        {
+            var addedContract = await AlreadyInDatabaseContract(x => x.ContractString = SampleContractString);
+
+            // Not including "Age" field
+            const string sampleMessage = "{\"id\": \"a21b2109-bd23-4205-ba53-b8df0fdd36bf\", \"Timestamp\": \"2019-07-23\",\"Name\":\"Saagar\"}";
+
+            var command = new TestMessage.Command
+            {
+                ContractId = addedContract.Id,
+                Message = JsonConvert.DeserializeObject(sampleMessage),
+                AllowSubset = true
+            };
+
+            var result = await Send(command);
+
+            result.IsValid.ShouldBeTrue();
+            result.MessageErrors.ShouldBeEmpty();
+        }
+
+        public async Task ShouldBeInvalidWhenMessageMatchesSubsetContract()
+        {
+            var addedContract = await AlreadyInDatabaseContract(x => x.ContractString = SampleContractString);
+
+            // Not including "Age" field
+            const string sampleMessage = "{\"id\": \"a21b2109-bd23-4205-ba53-b8df0fdd36bf\", \"Timestamp\": \"2019-07-23\",\"Name\":\"Saagar\"}";
+
+            var command = new TestMessage.Command
+            {
+                ContractId = addedContract.Id,
+                Message = JsonConvert.DeserializeObject(sampleMessage)
+            };
+
+            var result = await Send(command);
+
+            result.IsValid.ShouldBeFalse();
+            result.MessageErrors.ShouldBe(new List<string>
+            {
+                @"Message is missing expected property ""Age""."
+            });
+        }
     }
 }

--- a/src/Totem.Tests/Features/API/TestMessageTests.cs
+++ b/src/Totem.Tests/Features/API/TestMessageTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Totem.Features.API;
 using Newtonsoft.Json;
 using Shouldly;
+using Totem.Services;
 using static Totem.Tests.Testing;
 using static Totem.Tests.TestDataGenerator;
 
@@ -527,6 +528,53 @@ namespace Totem.Tests.Features.API
             result.MessageErrors.ShouldBe(new List<string>
             {
                 @"Message is missing expected property ""Age""."
+            });
+        }
+
+        public async Task ShouldBeValidWhenMessageWithObjectsMatchesSubsetContract()
+        {
+            var addedContract = await AlreadyInDatabaseContract(x => x.ContractString = SampleContractStringWithObject);
+
+            // Not including "Age" field
+            // Not including "Fullname => Lastname" field
+            const string sampleMessage = @"{""Fullname"": {""Firstname"": ""sample string""}, ""Id"": ""01234567-abcd-0123-abcd-0123456789ab"", ""Timestamp"": ""2019-01-01T18:14:29Z""}";
+
+            var command = new TestMessage.Command
+            {
+                ContractId = addedContract.Id,
+                Message = JsonConvert.DeserializeObject(sampleMessage),
+                AllowSubset = true
+            };
+
+            var result = await Send(command);
+
+            result.IsValid.ShouldBeTrue();
+            result.MessageErrors.ShouldBeEmpty();
+        }
+
+        public async Task ShouldBeInvalidWhenMessageWithObjectsMatchesSubsetContract()
+        {
+            var addedContract = await AlreadyInDatabaseContract(x => x.ContractString = SampleContractStringWithObject);
+
+            // Not including "Age" field
+            // Not including "Fullname => Lastname" field
+            const string sampleMessage = @"{""Fullname"": {""Firstname"": ""sample string""}, ""Id"": ""01234567-abcd-0123-abcd-0123456789ab"", ""Timestamp"": ""2019-01-01T18:14:29Z""}";
+
+            var command = new TestMessage.Command
+            {
+                ContractId = addedContract.Id,
+                Message = JsonConvert.DeserializeObject(sampleMessage)
+            };
+
+            var result = await Send(command);
+
+            const string separator = TesterService.ParentOfSymbol;
+
+            result.IsValid.ShouldBeFalse();
+            result.MessageErrors.ShouldBe(new List<string>
+            {
+                @"Message is missing expected property ""Age"".",
+                $@"The value for field ""Fullname{separator}Lastname"" was not found."
             });
         }
     }

--- a/src/Totem.Tests/Services/TesterServiceTests.cs
+++ b/src/Totem.Tests/Services/TesterServiceTests.cs
@@ -331,8 +331,8 @@ namespace Totem.Tests.Services
             result.MessageErrors[0].ShouldBe("\"Array\" does not have the required property(Items) for type(Array).");
         }
 
-        [TestingConvention.Input("String")]
-        [TestingConvention.Input("Integer")]
+        [Input("String")]
+        [Input("Integer")]
         public void ShouldFailValidationForArrayTypeWithIncorrectItemType(string dataType)
         {
             var contractDictionary = new CaseInsensitiveDictionary<SchemaObject>

--- a/src/Totem.Tests/TestDataGenerator.cs
+++ b/src/Totem.Tests/TestDataGenerator.cs
@@ -44,6 +44,47 @@ namespace Totem.Tests
             }
         }";
 
+        public const string SampleContractStringWithObject = @"{
+            ""Contract"": {
+                ""type"": ""object"",
+                ""properties"": {
+                    ""Id"": {
+                        ""$ref"": ""#/Guid""
+                    },
+                    ""Timestamp"": {
+                        ""type"": ""string"",
+                        ""format"": ""date-time"",
+                        ""example"": ""2019-05-12T18:14:29Z""
+                    },
+                    ""Fullname"": {
+                        ""type"": ""object"",
+                        ""properties"": {
+                            ""Firstname"": {
+                                ""type"": ""string"",
+                                ""example"": ""sample string""
+                            },
+                            ""Lastname"": {
+                                ""type"": ""string"",
+                                ""example"": ""sample string""
+                            }
+                        }
+                    },
+                    ""Age"": {
+                        ""type"": ""integer"",
+                        ""format"": ""int32"",
+                        ""example"": ""30""
+                    }
+                }
+            },
+            ""Guid"": {
+                ""type"": ""string"",
+                ""pattern"": ""^(([0-9a-f]){8}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){12})$"",
+                ""minLength"": 36,
+                ""maxLength"": 36,
+                ""example"": ""01234567-abcd-0123-abcd-0123456789ab""
+            }
+        }";
+
         public const string SampleContractStringWithReferenceError = @"{
             ""Contract"": {
                 ""type"": ""object"",

--- a/src/Totem/Features/API/TestMessage.cs
+++ b/src/Totem/Features/API/TestMessage.cs
@@ -17,6 +17,7 @@ namespace Totem.Features.API
         {
             public Guid ContractId { get; set; }
             public dynamic Message { get; set; }
+            public bool AllowSubset { get; set; }
         }
 
         public class CommandHandler : IRequestHandler<Command, Result>
@@ -60,7 +61,7 @@ namespace Totem.Features.API
 
                 if (isValid)
                 {
-                    var testResult = _testerService.Execute(contract.ContractString, message);
+                    var testResult = _testerService.Execute(contract.ContractString, message, request.AllowSubset);
 
                     if (!testResult.IsMessageValid)
                     {

--- a/src/Totem/Features/Contracts/MappingProfile.cs
+++ b/src/Totem/Features/Contracts/MappingProfile.cs
@@ -27,6 +27,7 @@ namespace Totem.Features.Contracts
                 .ForMember(x => x.ContractDescription, opt => opt.MapFrom(x => x.Description))
                 .ForMember(x => x.MessageErrors, opt => opt.Ignore())
                 .ForMember(x => x.TestMessage, opt => opt.Ignore())
+                .ForMember(x => x.AllowSubset, opt => opt.Ignore())
                 .ForMember(x => x.IsValid, opt => opt.Ignore())
                 .ForMember(x => x.WarningMessage, opt => opt.Ignore())
                 .ForMember(x => x.ContractObject, opt => opt.MapFrom(x => SchemaObject.BuildSchemaDictionary(x.ContractString, NoOp, NoOp)));

--- a/src/Totem/Features/Contracts/TestMessage.cs
+++ b/src/Totem/Features/Contracts/TestMessage.cs
@@ -45,6 +45,7 @@ namespace Totem.Features.Contracts
         {
             public Guid ContractId { get; set; }
             public string VersionNumber { get; set; }
+            public bool AllowSubset { get; set; }
             public string SampleMessage { get; set; }
         }
 
@@ -88,7 +89,7 @@ namespace Totem.Features.Contracts
 
                 if (isValid)
                 {
-                    var testResult = _testerService.Execute(contract.ContractString, request.SampleMessage);
+                    var testResult = _testerService.Execute(contract.ContractString, request.SampleMessage, request.AllowSubset);
 
                     if (!testResult.IsMessageValid)
                     {
@@ -110,6 +111,8 @@ namespace Totem.Features.Contracts
             public Guid ContractId { get; set; }
             [DisplayName("Version Number")]
             public string VersionNumber { get; set; }
+            [DisplayName("Allow Subset")]
+            public string AllowSubset { get; set; }
             [DisplayName("Description")]
             public string ContractDescription { get; set; }
             [DisplayName("Properties")]

--- a/src/Totem/Features/Contracts/TestMessage.cshtml
+++ b/src/Totem/Features/Contracts/TestMessage.cshtml
@@ -41,10 +41,14 @@
                 </div>
                 <div class="pull-left">
                     <form asp-controller="Contracts" asp-action="TestMessage">
-                        <input type="hidden" asp-for="ContractId" name="ContractId"/>
-                        <input type="hidden" asp-for="VersionNumber" name="VersionNumber"/>
+                        <input type="hidden" asp-for="ContractId" name="ContractId" />
+                        <input type="hidden" asp-for="VersionNumber" name="VersionNumber" />
                         <div class="form-group flex-container">
                             <textarea name="sampleMessage" asp-for="TestMessage" class="flex-expand tall"></textarea>
+                        </div>
+                        <div class="form-group form-check">
+                            <input class="form-check-input" asp-for="AllowSubset" type="checkbox" />
+                            <label class="form-check-label" asp-for="AllowSubset"></label>
                         </div>
                         <div class="form-group button-list">
                             <button asp-for="TestMessage" type="submit" class="btn btn-primary">Submit</button>
@@ -54,7 +58,7 @@
                 </div>
             </div>
             <div class="col-12">
-                @if (!String.IsNullOrEmpty(Model.TestMessage))
+                @if (!string.IsNullOrEmpty(Model.TestMessage))
                 {
                     if (Model.IsValid)
                     {

--- a/src/Totem/Services/TesterService.cs
+++ b/src/Totem/Services/TesterService.cs
@@ -14,7 +14,7 @@ namespace Totem.Services
         private static bool _isContractValid = true;
         private static string _contractErrorMessage = "";
 
-        public TestMessageResult Execute(string contract, string message)
+        public TestMessageResult Execute(string contract, string message, bool allowSubset = false)
         {
             var schemaDictionary = SchemaObject.BuildSchemaDictionary(contract, HandleReferenceError, HandleFailure);
 
@@ -56,7 +56,10 @@ namespace Totem.Services
             {
                 TestCases.Clear();
                 TestCases.Add(AreAllElementsInMessageContainedInContract(messageDictionary, contractDictionary));
-                TestCases.Add(AreAllElementsInContractContainedInMessage(messageDictionary, contractDictionary));
+                if (!allowSubset)
+                {
+                    TestCases.Add(AreAllElementsInContractContainedInMessage(messageDictionary, contractDictionary));
+                }
                 TestCases.Add(DoAllMessageValuesMatchDataTypes(messageDictionary, contractDictionary));
             }
 


### PR DESCRIPTION
- New property to TestMessage commands for the API and the Website.
- Checkbox added to the "Test Sample Message" form for allowing or not subsets for the messages to test.
- Integration tests for the API and the Website.
- Support for subsets of an "object" types.