### PR TITLE
Feature/#41 make required fields optional for basic api support

### DIFF
--- a/src/Totem.Tests/Features/Contracts/CreateTests.cs
+++ b/src/Totem.Tests/Features/Contracts/CreateTests.cs
@@ -207,8 +207,6 @@ namespace Totem.Tests.Features.Contracts
                 "Contract must be valid JSON.",
                 "'Contract' must not be empty.",
                 "'Description' must not be empty.",
-                "'Namespace' must not be empty.",
-                "'Type' must not be empty.",
                 "'Version Number' must follow semantic version system.",
                 "'Version Number' must not be empty.");
         }
@@ -241,77 +239,6 @@ namespace Totem.Tests.Features.Contracts
             };
 
             command.ShouldNotValidate("Contract must be defined as a valid OpenAPI schema.");
-        }
-
-        public void ShouldNotCreateWhenContractStringDoesNotHaveTimestamp()
-        {
-            var newContract = SampleContract();
-            var command = new Create.Command()
-            {
-                Description = newContract.Description,
-                ContractString = @"{
-                    ""Contract"": {
-                        ""type"": ""object"",
-                        ""properties"": {
-                            ""Id"": {
-                                ""$ref"": ""#/Guid""
-                            },
-                            ""Name"": {
-                                ""type"": ""string"",
-                                ""example"": ""John Doe""
-                            },
-                            ""Age"": {
-                                ""type"": ""integer"",
-                                ""format"": ""int32"",
-                                ""example"": ""30""
-                            }
-                        }
-                    },
-                    ""Guid"": {
-                        ""type"": ""string""
-                    }
-                }",
-                Namespace = newContract.Namespace,
-                Type = newContract.Type,
-                VersionNumber = newContract.VersionNumber
-            };
-
-            command.ShouldNotValidate("Contract must include a property Timestamp of format date-time.");
-        }
-
-        public void ShouldNotCreateWhenContractStringDoesNotHaveId()
-        {
-            var newContract = SampleContract();
-            var command = new Create.Command()
-            {
-                Description = newContract.Description,
-                ContractString = @"{
-                    ""Contract"": {
-                        ""type"": ""object"",
-                        ""properties"": {
-                            ""Timestamp"": {
-                            ""type"": ""string"",
-                            ""format"": ""date-time"",
-                            ""example"": ""2019-05-12T18:14:29Z""
-                            },
-                            ""Name"": {
-                            ""type"": ""string"",
-                            ""example"": ""John Doe""
-                            },
-                            ""Age"": {
-                            ""type"": ""integer"",
-                            ""format"": ""int32"",
-                            ""example"": ""30""
-                            }
-                        }
-                    }
-                }",
-                Namespace = newContract.Namespace,
-                Type = newContract.Type,
-                VersionNumber = newContract.VersionNumber
-            };
-
-            command.ShouldNotValidate("Contract must include a property ID of type Guid.");
         }
 
         public void ShouldNotCreateWhenContractStringTimestampDoesNotHaveFormat()

--- a/src/Totem.Tests/Features/Contracts/CreateTests.cs
+++ b/src/Totem.Tests/Features/Contracts/CreateTests.cs
@@ -60,6 +60,13 @@ namespace Totem.Tests.Features.Contracts
                             ""example"": ""30""
                         }
                     }
+                },
+                ""Guid"": {
+                    ""type"": ""string"",
+                    ""pattern"": ""^(([0-9a-f]){8}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){12})$"",
+                    ""minLength"": 36,
+                    ""maxLength"": 36,
+                    ""example"": ""01234567-abcd-0123-abcd-0123456789ab""
                 }
             }"; // No Id and no Timestamp
 

--- a/src/Totem.Tests/Features/Contracts/EditTests.cs
+++ b/src/Totem.Tests/Features/Contracts/EditTests.cs
@@ -81,6 +81,13 @@ namespace Totem.Tests.Features.Contracts
                                 ""example"": ""30""
                             }
                         }
+                    },
+                    ""Guid"": {
+                        ""type"": ""string"",
+                        ""pattern"": ""^(([0-9a-f]){8}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){12})$"",
+                        ""minLength"": 36,
+                        ""maxLength"": 36,
+                        ""example"": ""01234567-abcd-0123-abcd-0123456789ab""
                     }
                 }"; // No Id and no Timestamp
             });

--- a/src/Totem.Tests/Features/Contracts/EditTests.cs
+++ b/src/Totem.Tests/Features/Contracts/EditTests.cs
@@ -286,8 +286,6 @@ namespace Totem.Tests.Features.Contracts
                 "'Contract' must not be empty.",
                 "'Description' must not be empty.",
                 "'Id' must not be empty.",
-                "'Namespace' must not be empty.",
-                "'Type' must not be empty.",
                 "'Version Number' must follow semantic version system.",
                 "'Version Number' must not be empty.");
         }
@@ -391,60 +389,6 @@ namespace Totem.Tests.Features.Contracts
             command.ShouldNotValidate("Contract must be defined as a valid OpenAPI schema.");
         }
 
-        public async Task ShouldNotEditWhenContractStringDoesNotHaveTimestamp()
-        {
-            var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
-            {
-                Id = initialContract.Id,
-                Description = initialContract.Description,
-                ContractString = initialContract.ContractString,
-                Namespace = initialContract.Namespace,
-                Type = initialContract.Type,
-                VersionNumber = initialContract.VersionNumber
-            };
-
-            var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
-            {
-                Id = initialContract.Id,
-                Description = sampleContract.Description,
-                ContractString = @"{
-                    ""Contract"": {
-                        ""type"": ""object"",
-                        ""properties"": {
-                            ""Id"": {
-                                ""$ref"": ""#/Guid""
-                            },
-                            ""Name"": {
-                                ""type"": ""string"",
-                                ""example"": ""John Doe""
-                            },
-                            ""Age"": {
-                                ""type"": ""integer"",
-                                ""format"": ""int32"",
-                                ""example"": ""30""
-                            }
-                        }
-                    },
-                    ""Guid"": {
-                        ""type"": ""string""
-                    }
-                }",
-                Namespace = initialContract.Namespace,
-                Type = sampleContract.Type,
-                VersionNumber = sampleContract.VersionNumber
-            };
-
-            var command = new Edit.Command()
-            {
-                InitialContract = initialContractModel,
-                ModifiedContract = modifiedContractModel
-            };
-
-            command.ShouldNotValidate("Contract must include a property Timestamp of format date-time.");
-        }
-
         public async Task ShouldNotEditWhenContractStringTimestampDoesNotHaveFormat()
         {
             var initialContract = await AlreadyInDatabaseContract();
@@ -501,59 +445,6 @@ namespace Totem.Tests.Features.Contracts
             };
 
             command.ShouldNotValidate("The Timestamp property must have a format of date-time.");
-        }
-
-        public async Task ShouldNotEditWhenContractStringDoesNotHaveId()
-        {
-            var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
-            {
-                Id = initialContract.Id,
-                Description = initialContract.Description,
-                ContractString = initialContract.ContractString,
-                Namespace = initialContract.Namespace,
-                Type = initialContract.Type,
-                VersionNumber = initialContract.VersionNumber
-            };
-
-            var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
-            {
-                Id = initialContract.Id,
-                Description = sampleContract.Description,
-                ContractString = @"{
-                    ""Contract"": {
-                        ""type"": ""object"",
-                        ""properties"": {
-                            ""Timestamp"": {
-                            ""type"": ""string"",
-                            ""format"": ""date-time"",
-                            ""example"": ""2019-05-12T18:14:29Z""
-                            },
-                            ""Name"": {
-                            ""type"": ""string"",
-                            ""example"": ""John Doe""
-                            },
-                            ""Age"": {
-                            ""type"": ""integer"",
-                            ""format"": ""int32"",
-                            ""example"": ""30""
-                            }
-                        }
-                    }
-                }",
-                Namespace = initialContract.Namespace,
-                Type = sampleContract.Type,
-                VersionNumber = sampleContract.VersionNumber
-            };
-
-            var command = new Edit.Command()
-            {
-                InitialContract = initialContractModel,
-                ModifiedContract = modifiedContractModel
-            };
-
-            command.ShouldNotValidate("Contract must include a property ID of type Guid.");
         }
 
         public async Task ShouldEditWhenValidWithArray()

--- a/src/Totem/ClientApp/App.vue
+++ b/src/Totem/ClientApp/App.vue
@@ -2,6 +2,7 @@
   <div id="contract-list">
     <ContractGrid
       ref="rootContractGrid"
+      id="rootGrid"
       :rows="rows"
       :hide-ellipsis-menu="false"
       :edit-stack="editStack"
@@ -228,9 +229,7 @@ export default {
           }
         }
       }
-      if (this.rows.length === 0) {
-        disableSaveButton(true);
-      }
+      this.updateSaveButtonState();
     },
 
     saveField(object) {
@@ -357,10 +356,6 @@ export default {
         $('#ModifiedContract_ContractString')[0].value = this.modifiedContract;
         this.rows = parseContractArray(this.modifiedContract, 'contract-string-validation');
         this.isDescending = false;
-        if (typeof setSaveButton === 'function') {
-          // setSaveButton is defined in Edit.cshtml
-          setSaveButton(); // eslint-disable-line no-undef
-        }
         this.closeModal('addModel', true, false);
       }
     },
@@ -415,6 +410,17 @@ export default {
       this.rows = parseContractArray(newValue, 'contract-string-validation');
       this.closeModal('editManually');
       $('#contract-raw').scrollTop(0);
+    },
+
+    updateSaveButtonState() {
+      if (typeof setSaveButton === 'function') {
+          // setSaveButton is defined in Create.cshtml and Edit.cshtml
+          if (this.rows.length === 0 && setSaveButton.length > 0){
+            setSaveButton(true); // eslint-disable-line no-undef
+          } else {
+            setSaveButton(); // eslint-disable-line no-undef
+          }
+      }
     }
   }
 };

--- a/src/Totem/ClientApp/App.vue
+++ b/src/Totem/ClientApp/App.vue
@@ -228,6 +228,9 @@ export default {
           }
         }
       }
+      if (this.rows.length === 0) {
+        disableSaveButton(true);
+      }
     },
 
     saveField(object) {

--- a/src/Totem/ClientApp/features/contracts/__tests__/contractParser.spec.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/contractParser.spec.js
@@ -87,11 +87,11 @@ describe('parseContractArray', () => {
     expect(result[0].name).toEqual('Id');
     expect(result[0].type).toEqual('string');
     expect(result[0].reference).toEqual('Guid');
-    expect(result[0].isLocked).toEqual(true);
+    expect(result[0].isLocked).toEqual(undefined);
     expect(result[1].name).toEqual('Timestamp');
     expect(result[1].type).toEqual('string');
     expect(result[1].format).toEqual('date-time');
-    expect(result[1].isLocked).toEqual(true);
+    expect(result[1].isLocked).toEqual(undefined);
     expect(result[2].name).toEqual('Address');
     expect(result[2].type).toEqual('object');
     expect(result[2].isLocked).toEqual(undefined);

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/RootLevelSingleField.e2e.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/RootLevelSingleField.e2e.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 import VueSelector from 'testcafe-vue-selectors';
 import { Selector } from 'testcafe';
 import { baseUrl } from '../../../../testConfig/setup';
@@ -178,6 +179,39 @@ test('Deleting a previously saved root field', async t => {
     .eql(initialRowCount - 1)
     .expect(deletedRow.exists)
     .eql(false);
+});
+
+test('Delete all root fields', async t => {
+  await t.click(
+    Selector('tr.treegrid-body-row')
+      .nth(0)
+      .find('.edit-action')
+  );
+  await t.click(utils.deleteFieldBtn);
+
+  await t.click(
+    Selector('tr.treegrid-body-row')
+      .nth(0)
+      .find('.edit-action')
+  );
+  await t.click(utils.deleteFieldBtn);
+
+  await t.click(
+    Selector('tr.treegrid-body-row')
+      .nth(0)
+      .find('.edit-action')
+  );
+  await t.click(utils.deleteFieldBtn);
+
+  await t.click(
+    Selector('tr.treegrid-body-row')
+      .nth(0)
+      .find('.edit-action')
+  );
+  await t.click(utils.deleteFieldBtn);
+
+  await t.expect(Selector('tr.treegrid-body-row').count).eql(0);
+  await t.expect(Selector('#rootGrid .treegrid-empty-row').count).eql(1);
 });
 
 test('Adding and deleting a root field', async t => {

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/RootLevelSingleField.e2e.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/RootLevelSingleField.e2e.js
@@ -182,33 +182,16 @@ test('Deleting a previously saved root field', async t => {
 });
 
 test('Delete all root fields', async t => {
-  await t.click(
-    Selector('tr.treegrid-body-row')
-      .nth(0)
-      .find('.edit-action')
-  );
-  await t.click(utils.deleteFieldBtn);
+  const rowCount = await Selector('tr.treegrid-body-row').count;
 
-  await t.click(
-    Selector('tr.treegrid-body-row')
-      .nth(0)
-      .find('.edit-action')
-  );
-  await t.click(utils.deleteFieldBtn);
-
-  await t.click(
-    Selector('tr.treegrid-body-row')
-      .nth(0)
-      .find('.edit-action')
-  );
-  await t.click(utils.deleteFieldBtn);
-
-  await t.click(
-    Selector('tr.treegrid-body-row')
-      .nth(0)
-      .find('.edit-action')
-  );
-  await t.click(utils.deleteFieldBtn);
+  for (let i = 0; i < rowCount; i++) {
+    await t.click(
+      Selector('tr.treegrid-body-row')
+        .nth(0)
+        .find('.edit-action')
+    );
+    await t.click(utils.deleteFieldBtn);
+  }
 
   await t.expect(Selector('tr.treegrid-body-row').count).eql(0);
   await t.expect(Selector('#rootGrid .treegrid-empty-row').count).eql(1);

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/e2e-utils.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/e2e-utils.js
@@ -30,7 +30,7 @@ export async function loginAndNavigateToEditContract(t) {
   const loginButton = Selector('#loginSubmit');
   await t.click(loginButton);
 
-  const contractEditButton = Selector('.edit-contract').nth(1);
+  const contractEditButton = Selector('.edit-contract').nth(2);
   await t.click(contractEditButton);
 }
 

--- a/src/Totem/ClientApp/features/contracts/contractParser.js
+++ b/src/Totem/ClientApp/features/contracts/contractParser.js
@@ -63,16 +63,6 @@ export const parseContractArray = (contractString, validationFieldId) => {
   const { properties } = schema.Contract;
   const propertyArray = getModalRows(properties, schema);
 
-  // Hard-code the "required" fields for now
-  propertyArray.forEach(rootProperty => {
-    if (rootProperty.name.toLowerCase() === 'id') {
-      rootProperty.isLocked = true;
-    }
-    if (rootProperty.name.toLowerCase() === 'timestamp') {
-      rootProperty.isLocked = true;
-    }
-  });
-
   return propertyArray;
 };
 

--- a/src/Totem/Features/Contracts/Create.cs
+++ b/src/Totem/Features/Contracts/Create.cs
@@ -116,8 +116,6 @@ namespace Totem.Features.Contracts
 
                 RuleFor(m => m.Description).NotEmpty();
                 RuleFor(m => m.ContractString).NotEmpty().StringMustBeValidContract();
-                RuleFor(m => m.Namespace).NotEmpty();
-                RuleFor(m => m.Type).NotEmpty();
                 RuleFor(m => m.VersionNumber).NotEmpty().Must(BeAValidVersion).WithMessage("'Version Number' must follow semantic version system.");
                 RuleFor(m => m).MustAsync((m, cancellationToken) => ValidationExtensions.IsUniqueContract(m.Id, m.VersionNumber, dbContext, cancellationToken))
                     .WithMessage(m => $"Contract Id '{m.Id}' with Version '{m.VersionNumber}' already exist.");

--- a/src/Totem/Features/Contracts/Create.cshtml
+++ b/src/Totem/Features/Contracts/Create.cshtml
@@ -86,8 +86,12 @@
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
     <script src="~/dist/main.js" asp-append-version="true"></script>
     <script>
-        function disableSaveButton(shouldDisable = false) {
-            $("#createContractSave").attr("disabled", shouldDisable);
+        function setSaveButton(isGridEmpty) {
+            if (isGridEmpty) {
+                $("#createContractSave").attr("disabled", true);
+            } else {
+                $("#createContractSave").attr("disabled", false);
+            }
         }
     </script>
 }

--- a/src/Totem/Features/Contracts/Create.cshtml
+++ b/src/Totem/Features/Contracts/Create.cshtml
@@ -75,7 +75,7 @@
                 <span asp-validation-for="DeprecationDate" class="text-danger"></span>
             </div>
             <div class="form-group button-list">
-                <button type="submit" class="btn btn-primary"><i class="far fa-save"></i>Save</button>
+                <button id="createContractSave" type="submit" class="btn btn-primary"><i class="far fa-save"></i>Save</button>
                 <a asp-action="Index" class="btn btn-success">Cancel</a>
             </div>
         </div>
@@ -85,4 +85,9 @@
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
     <script src="~/dist/main.js" asp-append-version="true"></script>
+    <script>
+        function disableSaveButton(shouldDisable = false) {
+            $("#createContractSave").attr("disabled", shouldDisable);
+        }
+    </script>
 }

--- a/src/Totem/Features/Contracts/Edit.cs
+++ b/src/Totem/Features/Contracts/Edit.cs
@@ -131,8 +131,6 @@ namespace Totem.Features.Contracts
                 RuleFor(m => m.ModifiedContract.Id).NotEmpty().WithName("Id");
                 RuleFor(m => m.ModifiedContract.Description).NotEmpty().WithName("Description");
                 RuleFor(m => m.ModifiedContract.ContractString).NotEmpty().StringMustBeValidContract();
-                RuleFor(m => m.ModifiedContract.Namespace).NotEmpty().WithName("Namespace");
-                RuleFor(m => m.ModifiedContract.Type).NotEmpty().WithName("Type");
                 RuleFor(m => m.ModifiedContract.VersionNumber).NotEmpty().WithName("Version Number").Must(BeAValidVersion).WithMessage("'Version Number' must follow semantic version system.");
                 RuleFor(m => m).MustAsync((m, cancellationToken) =>
                         ValidationExtensions.IsUniqueContract(m.ModifiedContract.Id, m.ModifiedContract.VersionNumber, dbContext, cancellationToken))

--- a/src/Totem/Features/Contracts/Edit.cshtml
+++ b/src/Totem/Features/Contracts/Edit.cshtml
@@ -112,11 +112,15 @@
                 });
         });
 
+        function disableSaveButton(shouldDisable = false) {
+            $("#saveEdits").attr("disabled", shouldDisable);
+        }
+
         function setSaveButton() {
             if (valuesHaveChanged()) {
-                $("#saveEdits").attr("disabled", false);
+                disableSaveButton(false);
             } else {
-                $("#saveEdits").attr("disabled", true);
+                disableSaveButton(true);
             }
         }
 

--- a/src/Totem/Features/Contracts/Edit.cshtml
+++ b/src/Totem/Features/Contracts/Edit.cshtml
@@ -112,15 +112,11 @@
                 });
         });
 
-        function disableSaveButton(shouldDisable = false) {
-            $("#saveEdits").attr("disabled", shouldDisable);
-        }
-
         function setSaveButton() {
-            if (valuesHaveChanged()) {
-                disableSaveButton(false);
+            if (valuesHaveChanged() && !($("#rootGrid .treegrid-empty-row").length === 1)) {
+                $("#saveEdits").attr("disabled", false);
             } else {
-                disableSaveButton(true);
+                $("#saveEdits").attr("disabled", true);
             }
         }
 

--- a/src/Totem/Features/Contracts/MappingProfile.cs
+++ b/src/Totem/Features/Contracts/MappingProfile.cs
@@ -13,6 +13,8 @@ namespace Totem.Features.Contracts
                 .ForMember(x => x.UpdateInst, opt => opt.Ignore())
                 .ForMember(x => x.CreatedDate, opt => opt.Ignore())
                 .ForMember(x => x.DisplayOnContractList, opt => opt.Ignore())
+                .ForMember(x => x.Type, opt => opt.NullSubstitute(""))
+                .ForMember(x => x.Namespace, opt => opt.NullSubstitute(""))
                 .ReverseMap();
 
             CreateMap<Contract, Details.ViewModel>()
@@ -20,6 +22,8 @@ namespace Totem.Features.Contracts
 
             CreateMap<Edit.EditModel, Contract>()
                 .ForMember(x => x.CreatedDate, opt => opt.Ignore())
+                .ForMember(x => x.Type, opt => opt.NullSubstitute(""))
+                .ForMember(x => x.Namespace, opt => opt.NullSubstitute(""))
                 .ReverseMap();
 
             CreateMap<Contract, TestMessage.ViewModel>()

--- a/src/Totem/Features/Shared/ValidationExtensions.cs
+++ b/src/Totem/Features/Shared/ValidationExtensions.cs
@@ -65,33 +65,40 @@ namespace Totem.Features.Shared
                             }
                         }
 
-                        var idKey = contractObject.Properties.Keys.FirstOrDefault(k => k.EqualsCaseInsensitive("ID"));
-
-                        if (idKey != null)
+                        if (contractObject.Properties.Count == 0)
                         {
-                            var idProperty = contractObject.Properties[idKey];
-
-                            if (idProperty.Type != null && !idProperty.Type.Equals(DataType.String.Value) ||
-                                idProperty.Reference != "Guid" ||
-                                contractDictionary["Guid"] == null)
-                            {
-                                context.AddFailure("Contract must include a property ID of type Guid.");
-                            }
+                            context.AddFailure("An empty contract cannot be saved.");
                         }
-
-                        var timestampKey = contractObject.Properties.Keys.FirstOrDefault(k => k.EqualsCaseInsensitive("Timestamp"));
-
-                        if (timestampKey != null)
+                        else
                         {
-                            var timestampProperty = contractObject.Properties[timestampKey];
+                            var idKey = contractObject.Properties.Keys.FirstOrDefault(k => k.EqualsCaseInsensitive("ID"));
 
-                            if (timestampProperty.Format == null || !timestampProperty.Format.Equals(Format.DateTime.Value))
+                            if (idKey != null)
                             {
-                                context.AddFailure("The Timestamp property must have a format of date-time.");
-                            }
-                        }
+                                var idProperty = contractObject.Properties[idKey];
 
-                        CheckProperties(contractObject.Properties, context);
+                                if (idProperty.Type != null && !idProperty.Type.Equals(DataType.String.Value) ||
+                                    idProperty.Reference != "Guid" ||
+                                    contractDictionary["Guid"] == null)
+                                {
+                                    context.AddFailure("Contract must include a property ID of type Guid.");
+                                }
+                            }
+
+                            var timestampKey = contractObject.Properties.Keys.FirstOrDefault(k => k.EqualsCaseInsensitive("Timestamp"));
+
+                            if (timestampKey != null)
+                            {
+                                var timestampProperty = contractObject.Properties[timestampKey];
+
+                                if (timestampProperty.Format == null || !timestampProperty.Format.Equals(Format.DateTime.Value))
+                                {
+                                    context.AddFailure("The Timestamp property must have a format of date-time.");
+                                }
+                            }
+
+                            CheckProperties(contractObject.Properties, context);
+                        }
                     }
                     catch (Exception)
                     {

--- a/src/Totem/Features/Shared/ValidationExtensions.cs
+++ b/src/Totem/Features/Shared/ValidationExtensions.cs
@@ -61,24 +61,31 @@ namespace Totem.Features.Shared
                         {
                             if (!CheckDataType(contractObject.Type))
                             {
-                                context.AddFailure($"Contract does not have a valid type.");
+                                context.AddFailure("Contract does not have a valid type.");
                             }
                         }
 
                         var idKey = contractObject.Properties.Keys.FirstOrDefault(k => k.EqualsCaseInsensitive("ID"));
-                        if (idKey != null && (contractObject.Properties[idKey].Type != null &&
-                                              !contractObject.Properties[idKey].Type.Equals(DataType.String.Value)) || idKey != null &&
-                            (contractObject.Properties[idKey].Reference != "Guid" || contractDictionary["Guid"] == null))
+
+                        if (idKey != null)
                         {
-                            context.AddFailure("Contract must include a property ID of type Guid.");
+                            var idProperty = contractObject.Properties[idKey];
+
+                            if (idProperty.Type != null && !idProperty.Type.Equals(DataType.String.Value) ||
+                                idProperty.Reference != "Guid" ||
+                                contractDictionary["Guid"] == null)
+                            {
+                                context.AddFailure("Contract must include a property ID of type Guid.");
+                            }
                         }
 
-                        var timestampKey =
-                            contractObject.Properties.Keys.FirstOrDefault(k => k.EqualsCaseInsensitive("Timestamp"));
+                        var timestampKey = contractObject.Properties.Keys.FirstOrDefault(k => k.EqualsCaseInsensitive("Timestamp"));
+
                         if (timestampKey != null)
                         {
-                            if (contractObject.Properties[timestampKey].Format == null || !contractObject
-                                    .Properties[timestampKey].Format.Equals(Format.DateTime.Value))
+                            var timestampProperty = contractObject.Properties[timestampKey];
+
+                            if (timestampProperty.Format == null || !timestampProperty.Format.Equals(Format.DateTime.Value))
                             {
                                 context.AddFailure("The Timestamp property must have a format of date-time.");
                             }

--- a/src/Totem/Features/Shared/ValidationExtensions.cs
+++ b/src/Totem/Features/Shared/ValidationExtensions.cs
@@ -66,20 +66,16 @@ namespace Totem.Features.Shared
                         }
 
                         var idKey = contractObject.Properties.Keys.FirstOrDefault(k => k.EqualsCaseInsensitive("ID"));
-                        if (idKey == null || (contractObject.Properties[idKey].Type != null &&
-                                              !contractObject.Properties[idKey].Type.Equals(DataType.String.Value)) ||
-                            contractObject.Properties[idKey].Reference != "Guid" || contractDictionary["Guid"] == null)
+                        if (idKey != null && (contractObject.Properties[idKey].Type != null &&
+                                              !contractObject.Properties[idKey].Type.Equals(DataType.String.Value)) || idKey != null &&
+                            (contractObject.Properties[idKey].Reference != "Guid" || contractDictionary["Guid"] == null))
                         {
                             context.AddFailure("Contract must include a property ID of type Guid.");
                         }
 
                         var timestampKey =
                             contractObject.Properties.Keys.FirstOrDefault(k => k.EqualsCaseInsensitive("Timestamp"));
-                        if (timestampKey == null)
-                        {
-                            context.AddFailure("Contract must include a property Timestamp of format date-time.");
-                        }
-                        else
+                        if (timestampKey != null)
                         {
                             if (contractObject.Properties[timestampKey].Format == null || !contractObject
                                     .Properties[timestampKey].Format.Equals(Format.DateTime.Value))

--- a/src/Totem/package-lock.json
+++ b/src/Totem/package-lock.json
@@ -7145,9 +7145,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
+      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -12686,13 +12686,13 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.5.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.9.tgz",
-      "integrity": "sha512-WpT0RqsDtAWPNJK955DEnb6xjymR8Fn0OlK4TT4pS0ASYsVPqr5ELhgwOwLCP5J5vHeJ4xmMmz3DEgdqC10JeQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.1.tgz",
+      "integrity": "sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {


### PR DESCRIPTION
- Removed required validations on Namespace and Type from Edit and Create flows and modified MappingProfile to have an empty string in place of null for them.
- Refactored setSaveButton with disableSaveButton and added a similar function on Create to disable the Save button on the page when all rows are deleted from the root grid. 
- Removed the locks on timestamp and id. 
- Removed checks for null for id and timestamp.Added a method updateSaveButton and added a setSaveButton on Create.cshtml to control save button state on both Edit and Create. This also takes care of the case when the root grid is empty.
- Refactored tests (backend and ui) to reflect the changes in validations