### PR TITLE
Bug/#24 Responsive header menu not working at mobile size

### DIFF
--- a/src/Totem/ClientApp/app.js
+++ b/src/Totem/ClientApp/app.js
@@ -1,6 +1,5 @@
 import './assets/style/main.scss';
 import Vue from 'vue';
-import 'bootstrap/js/dist/dropdown';
 import App from './App.vue';
 
 new Vue({

--- a/src/Totem/Features/Shared/_Layout.cshtml
+++ b/src/Totem/Features/Shared/_Layout.cshtml
@@ -45,7 +45,9 @@
     </environment>
 
     <script src="~/lib/jquery-ui-1.12.1/jquery-ui.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+
     @RenderSection("Scripts", required: false)
 </body>
 </html>

--- a/src/Totem/Features/Shared/_Layout.cshtml
+++ b/src/Totem/Features/Shared/_Layout.cshtml
@@ -45,8 +45,7 @@
     </environment>
 
     <script src="~/lib/jquery-ui-1.12.1/jquery-ui.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
     @RenderSection("Scripts", required: false)
 </body>
 </html>

--- a/src/Totem/Features/Shared/_LoginPartial.cshtml
+++ b/src/Totem/Features/Shared/_LoginPartial.cshtml
@@ -3,10 +3,10 @@
 
 @if (SignInManager.IsSignedIn(User))
 {
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo02" aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarToggler">
         <span class="navbar-toggler-icon"></span>
     </button>
-    <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
+    <div class="collapse navbar-collapse" id="navbarToggler">
         <ul class="navbar-nav navbar-right">
             <li class="navbar-user">
                 <span class="navbar-user">@UserManager.GetUserName(User)</span>


### PR DESCRIPTION
- Refactored the toggle button and collapsible navbar to simplify and improve identifier naming.
- Removed popper.js CDN and added bootstrap.js CDN which allows the header menu (hamburger at small screen widths) and the edit manually dropdown to work simultaneously. 