### PR TITLE
Feature/#27 prevent creating empty objects

### DIFF
--- a/src/Totem.Tests/Features/Contracts/CreateTests.cs
+++ b/src/Totem.Tests/Features/Contracts/CreateTests.cs
@@ -480,6 +480,99 @@ namespace Totem.Tests.Features.Contracts
             createdContract.ShouldMatch(newContract);
         }
 
+        public void ShouldNotCreateWhenAnObjectHasNoPropertiesObject()
+        {
+            var newContract = SampleContract();
+            var command = new Create.Command()
+            {
+                Description = newContract.Description,
+                ContractString = @"{
+                    ""Contract"": {
+                        ""type"": ""object"",
+                        ""properties"": {
+                            ""Id"": {
+                                ""$ref"": ""#/Guid""
+                            },
+                            ""Timestamp"": {
+                                ""type"": ""string"",
+                                ""format"": ""date-time"",
+                                ""example"": ""2019-05-12T18:14:29Z""
+                            },
+                            ""Name"": {
+                                ""type"": ""string"",
+                                ""example"": ""John Doe""
+                            },
+                            ""Age"": {
+                                ""type"": ""integer"",
+                                ""format"": ""int32"",
+                                ""example"": ""30""
+                            },
+                            ""LevelOne"": {
+                                ""type"": ""object"",
+                            }
+                        }
+                    },
+                    ""Guid"": {
+                        ""type"": ""string""
+                    }
+                }",
+                Namespace = newContract.Namespace,
+                Type = newContract.Type,
+                VersionNumber = newContract.VersionNumber
+            };
+
+            command.ShouldNotValidate("Contract must be defined as a valid OpenAPI schema.",
+                "The definition of \"LevelOne\" is incorrect. \"object\" data type requires a 'Properties' object."
+            );
+        }
+
+        public void ShouldNotCreateWhenAnObjectHasZeroProperties()
+        {
+            var newContract = SampleContract();
+            var command = new Create.Command()
+            {
+                Description = newContract.Description,
+                ContractString = @"{
+                    ""Contract"": {
+                        ""type"": ""object"",
+                        ""properties"": {
+                            ""Id"": {
+                                ""$ref"": ""#/Guid""
+                            },
+                            ""Timestamp"": {
+                                ""type"": ""string"",
+                                ""format"": ""date-time"",
+                                ""example"": ""2019-05-12T18:14:29Z""
+                            },
+                            ""Name"": {
+                                ""type"": ""string"",
+                                ""example"": ""John Doe""
+                            },
+                            ""Age"": {
+                                ""type"": ""integer"",
+                                ""format"": ""int32"",
+                                ""example"": ""30""
+                            },
+                            ""LevelOne"": {
+                                ""type"": ""object"",
+                                ""properties"": {
+                                }
+                            }
+                        }
+                    },
+                    ""Guid"": {
+                        ""type"": ""string""
+                    }
+                }",
+                Namespace = newContract.Namespace,
+                Type = newContract.Type,
+                VersionNumber = newContract.VersionNumber
+            };
+
+            command.ShouldNotValidate("The definition of \"LevelOne\" is incorrect. \"object\" data type requires at least one nested property. It can not be empty.");
+
+        }
+
         public async Task ShouldCreateWhenValidWithArrayAndNestedObject()
         {
             var oldCount = CountRecords<Contract>();

--- a/src/Totem.Tests/Features/Contracts/EditTests.cs
+++ b/src/Totem.Tests/Features/Contracts/EditTests.cs
@@ -722,6 +722,135 @@ namespace Totem.Tests.Features.Contracts
             modifiedContract.VersionNumber.ShouldBe(initialContract.VersionNumber);
         }
 
+        public async Task ShouldNotEditWhenAnObjectHasNoPropertiesObject()
+        {
+            var initialContract = await AlreadyInDatabaseContract();
+            var initialContractModel = new Edit.EditModel()
+            {
+                Id = initialContract.Id,
+                Description = initialContract.Description,
+                ContractString = initialContract.ContractString,
+                Namespace = initialContract.Namespace,
+                Type = initialContract.Type,
+                VersionNumber = initialContract.VersionNumber
+            };
+
+            var sampleContract = SampleContract();
+            var modifiedContractModel = new Edit.EditModel()
+            {
+                Id = initialContract.Id,
+                Description = sampleContract.Description,
+                ContractString = @"{
+                    ""Contract"": {
+                        ""type"": ""object"",
+                        ""properties"": {
+                            ""Id"": {
+                                ""$ref"": ""#/Guid""
+                            },
+                            ""Timestamp"": {
+                                ""type"": ""string"",
+                                ""format"": ""date-time"",
+                                ""example"": ""2019-05-12T18:14:29Z""
+                            },
+                            ""Name"": {
+                                ""type"": ""string"",
+                                ""example"": ""John Doe""
+                            },
+                            ""Age"": {
+                                ""type"": ""integer"",
+                                ""format"": ""int32"",
+                                ""example"": ""30""
+                            },
+                            ""LevelOne"": {
+                                ""type"": ""object"",
+                            }
+                        }
+                    },
+                    ""Guid"": {
+                        ""type"": ""string""
+                    }
+                }",
+                Namespace = initialContract.Namespace,
+                Type = sampleContract.Type,
+                VersionNumber = sampleContract.VersionNumber
+            };
+
+            var command = new Edit.Command()
+            {
+                InitialContract = initialContractModel,
+                ModifiedContract = modifiedContractModel
+            };
+
+            command.ShouldNotValidate("Contract must be defined as a valid OpenAPI schema.",
+                "The definition of \"LevelOne\" is incorrect. \"object\" data type requires a 'Properties' object."
+            );
+        }
+
+        public async Task ShouldNotEditWhenAnObjectHasZeroProperties()
+        {
+            var initialContract = await AlreadyInDatabaseContract();
+            var initialContractModel = new Edit.EditModel()
+            {
+                Id = initialContract.Id,
+                Description = initialContract.Description,
+                ContractString = initialContract.ContractString,
+                Namespace = initialContract.Namespace,
+                Type = initialContract.Type,
+                VersionNumber = initialContract.VersionNumber
+            };
+
+            var sampleContract = SampleContract();
+            var modifiedContractModel = new Edit.EditModel()
+            {
+                Id = initialContract.Id,
+                Description = sampleContract.Description,
+                ContractString = @"{
+                    ""Contract"": {
+                        ""type"": ""object"",
+                        ""properties"": {
+                            ""Id"": {
+                                ""$ref"": ""#/Guid""
+                            },
+                            ""Timestamp"": {
+                                ""type"": ""string"",
+                                ""format"": ""date-time"",
+                                ""example"": ""2019-05-12T18:14:29Z""
+                            },
+                            ""Name"": {
+                                ""type"": ""string"",
+                                ""example"": ""John Doe""
+                            },
+                            ""Age"": {
+                                ""type"": ""integer"",
+                                ""format"": ""int32"",
+                                ""example"": ""30""
+                            },
+                            ""LevelOne"": {
+                                ""type"": ""object"",
+                                ""properties"": {
+                                }
+                            }
+                        }
+                    },
+                    ""Guid"": {
+                        ""type"": ""string""
+                    }
+                }",
+                Namespace = initialContract.Namespace,
+                Type = sampleContract.Type,
+                VersionNumber = sampleContract.VersionNumber
+            };
+
+            var command = new Edit.Command()
+            {
+                InitialContract = initialContractModel,
+                ModifiedContract = modifiedContractModel
+            };
+
+            command.ShouldNotValidate("The definition of \"LevelOne\" is incorrect. \"object\" data type requires at least one nested property. It can not be empty.");
+
+        }
+
         public async Task ShouldEditWhenValidWithArrayAndNestedObject()
         {
             var initialContract = await AlreadyInDatabaseContract();

--- a/src/Totem/ClientApp/features/contracts/AddModelModalWindow.vue
+++ b/src/Totem/ClientApp/features/contracts/AddModelModalWindow.vue
@@ -165,10 +165,10 @@ export default {
       };
 
       this.isArray = last(this.editStack).items !== undefined;
-
+      this.isEditModal = last(this.editStack).rowId !== undefined;
       this.showFieldNameTextbox = false;
-      if (last(this.editStack).rowId !== undefined) {
-        this.isEditModal = true;
+
+      if (this.isEditModal) {
         this.computedModalTitle = 'Update Model';
         this.successBtn = {
           id: 'saveModelBtn',

--- a/src/Totem/Features/Shared/ValidationExtensions.cs
+++ b/src/Totem/Features/Shared/ValidationExtensions.cs
@@ -130,6 +130,11 @@ namespace Totem.Features.Shared
                         {
                             context.AddFailure($"The definition of \"{propertyName}\" is incorrect. \"{type}\" data type requires a 'Properties' object.");
                         }
+                        else if
+                            (propertyObject.Properties.Count == 0)
+                        {
+                            context.AddFailure($"The definition of \"{propertyName}\" is incorrect. \"{type}\" data type requires at least one nested property. It can not be empty.");
+                        }
                         else
                         {
                             CheckProperties(propertyObject.Properties, context);


### PR DESCRIPTION
- Added a validation to prevent saving a contract with an empty object field.
- Added Create and Edit tests to validate the flows when trying to save a contract while editing and creating a contract with an empty object or an object with no properties object.