### PR TITLE
Bug/#31 changes to a model name do not persist after editing a child

### DIFF
--- a/src/Totem/ClientApp/App.vue
+++ b/src/Totem/ClientApp/App.vue
@@ -374,7 +374,6 @@ export default {
         // Add the newly added model name to the dropdown options
         this.addNewModelToOptions(updatedModel);
       } else {
-        this.updateExistingOption(model.name, updatedModel);
         this.updateParent(updatedModel);
         this.options = reorderOptions(this.options);
       }
@@ -406,6 +405,7 @@ export default {
         $('#contract-raw')[0].value = JSON.stringify(JSON.parse(this.modifiedContract), null, 2);
         $('#ModifiedContract_ContractString')[0].value = this.modifiedContract;
         this.rows = parseContractArray(this.modifiedContract, 'contract-string-validation');
+        this.resetDefaultOptions();
         this.isDescending = false;
         this.closeModal('addModel', true, false);
       }
@@ -473,6 +473,11 @@ export default {
       });
     },
 
+    resetDefaultOptions() {
+      this.options = this.options.filter(option => option.isDefault === true);
+      this.addModelsToOptions(this.rows);
+    },
+
     importContract() {
       const message = $('#import-message')[0].value;
       const contractBasedOnMessage = buildContractFromMessage(message);
@@ -481,8 +486,7 @@ export default {
         'contract-string-validation'
       );
 
-      this.options = this.options.filter(option => option.isDefault === true);
-      this.addModelsToOptions(this.rows);
+      this.resetDefaultOptions();
 
       $('#contract-raw')[0].value = JSON.stringify(contractBasedOnMessage, null, 2);
       $('#ModifiedContract_ContractString')[0].value = JSON.stringify(contractBasedOnMessage);

--- a/src/Totem/ClientApp/App.vue
+++ b/src/Totem/ClientApp/App.vue
@@ -341,7 +341,7 @@ export default {
           // Existing model row ID not found, so add as a new row
           this.modalRows.push(updatedModel);
         }
-        this.currentParentName = last(this.editStack).name;
+        this.currentParentName = updatedModel.parentName ? updatedModel.parentName : last(this.editStack).name;
         last(this.editStack).properties = deepCopy(this.modalRows);
       } else {
         // update root contract

--- a/src/Totem/ClientApp/features/contracts/AddModelModalWindow.vue
+++ b/src/Totem/ClientApp/features/contracts/AddModelModalWindow.vue
@@ -180,7 +180,10 @@ export default {
 
     close() {
       if (this.editStack.length > 0) {
-        this.editStack.pop();
+        const lastNestedModel = this.editStack.pop();
+        if (this.editStack.length > 0) {
+          last(this.editStack).name = lastNestedModel.parentName;
+        }
         this.$emit('close', 'addModel', false, false);
       } else {
         this.$emit('close', 'addModel', false, true);
@@ -188,7 +191,9 @@ export default {
     },
 
     showModelWindow(field) {
-      field.parentId = findParent(this.$parent.rows, field).rowId;
+      const parent = findParent(this.$parent.rows, field);
+      field.parentId = parent.rowId;
+      field.parentName = this.modalFieldName;
       this.editStack.push(deepCopy(field));
       this.objectRows = deepCopy(field.properties);
       this.$parent.modalRows = deepCopy(this.objectRows);
@@ -198,7 +203,9 @@ export default {
 
     showFieldWindow(field) {
       let deepField = {};
-      this.modalFieldName = this.parentName;
+      if (this.parentName != this.modalFieldName) {
+        last(this.editStack).name = this.modalFieldName;
+      }
       if (field !== undefined) {
         deepField = deepCopy(field);
       }

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedArrayModelField.e2e.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedArrayModelField.e2e.js
@@ -787,6 +787,103 @@ test('Cancel edits to a nested field in the model', async t => {
     .eql(false);
 });
 
+test('Parent model name edits persist after opening a field modal', async t => {
+  await addNewNestedModelAtRoot(t);
+
+  const rowToEdit = Selector('tr.treegrid-body-row').withText('testModel');
+  const editFieldBtn = rowToEdit.find('.edit-action');
+  await t.click(editFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('testModel');
+
+  // Edit the model name
+  await t.typeText(utils.modelName, 'testModelEdits', { replace: true });
+
+  const nestedFieldRowToEdit = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('testProperty');
+  const nestedFieldEditFieldBtn = nestedFieldRowToEdit.find('.edit-action');
+  await t.click(nestedFieldEditFieldBtn);
+
+  await t.expect(utils.inputFieldName.value).eql('testProperty');
+  await t.expect(utils.inputFieldExample.value).eql('123');
+  await t.expect(utils.inputType.getVue(({ props }) => props.value.displayName)).eql('Integer');
+
+  await t.click(utils.cancelFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('testModelEdits');
+});
+
+test('Parent model name edits persist after opening a model modal', async t => {
+  await addNewNestedModelAtRoot(t);
+
+  const rowToEdit = Selector('tr.treegrid-body-row').withText('testModel');
+  const editFieldBtn = rowToEdit.find('.edit-action');
+  await t.click(editFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('testModel');
+
+  // Edit the model name
+  await t.typeText(utils.modelName, 'testModelEdits', { replace: true });
+
+  const nestedModelRowToEdit = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('nestedModel');
+  const nestedModelEditFieldBtn = nestedModelRowToEdit.find('.edit-action');
+  await t.click(nestedModelEditFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('nestedModel');
+
+  await t.click(utils.cancelModelBtn);
+
+  await t.expect(utils.modelName.value).eql('testModelEdits');
+});
+
+test('Parent model name edits persist after edits to a nested model', async t => {
+  await addNewNestedModelAtRoot(t);
+
+  const rowToEdit = Selector('tr.treegrid-body-row').withText('testModel');
+  const editFieldBtn = rowToEdit.find('.edit-action');
+  await t.click(editFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('testModel');
+
+  // Edit the model name
+  await t.typeText(utils.modelName, 'testModelEdits', { replace: true });
+
+  const nestedModelRowToEdit = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('nestedModel');
+  const nestedModelEditFieldBtn = nestedModelRowToEdit.find('.edit-action');
+  await t.click(nestedModelEditFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('nestedModel');
+
+  // Edit the child model name
+  await t.typeText(utils.modelName, 'editedNestedModel', { replace: true });
+  const childModelFieldRowToEdit = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('testProperty');
+  const nestedFieldEditFieldBtn = childModelFieldRowToEdit.find('.edit-action');
+  await t.click(nestedFieldEditFieldBtn);
+
+  await t.expect(utils.inputFieldName.value).eql('testProperty');
+  await t.expect(utils.inputFieldExample.value).eql('123');
+  await t.expect(utils.inputType.getVue(({ props }) => props.value.displayName)).eql('Integer');
+
+  await t.click(utils.cancelFieldBtn);
+
+  await t.click(utils.saveModelBtn);
+
+  await t.expect(nestedModelRowToEdit.exists).eql(false);
+
+  const editedNestedModelRow = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('editedNestedModel');
+  await t.expect(editedNestedModelRow.exists).eql(true);
+  await t.expect(utils.modelName.value).eql('testModelEdits');
+});
+
 test('Cancel add new model to an already nested model', async t => {
   await addNewNestedModelAtRoot(t);
   const initialRowCount = await Selector('tr.treegrid-body-row').count;
@@ -905,4 +1002,141 @@ test('Change the type of a child field to a model', async t => {
     .contains('object')
     .expect(new3xNestedPropertyRow.exists)
     .eql(true);
+});
+
+test('Edit a child model of a prior nested model and add a new model using the prior nested model with the child edits', async t => {
+  await addNewNestedModelAtRoot(t);
+  const initialRowCount = await Selector('tr.treegrid-body-row').count;
+  // Add a new field based on previous model
+  await t.click(utils.addNewFieldBtn);
+
+  await t.typeText(utils.inputFieldName, 'testSecondModel');
+  await t.click(utils.inputType).click(Selector('li').withText('testModel'));
+  await t.expect(utils.inputFieldExample.hasAttribute('disabled')).ok();
+
+  await t.click(utils.saveFieldBtn);
+
+  // Edit the nested field of the original model from the root and save
+  const objectRowToEdit = Selector('tr.treegrid-body-row').withText('nestedModel');
+  const editFieldBtn = objectRowToEdit.find('.edit-action');
+  await t.click(editFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('nestedModel');
+  await t.typeText(utils.modelName, 'editedNestedModel', { replace: true });
+  await t.click(utils.saveModelBtn);
+
+  // Add a third field based on the previous model
+  await t.click(utils.addNewFieldBtn);
+
+  await t.typeText(utils.inputFieldName, 'testThirdModel');
+  await t.click(utils.inputType).click(Selector('li').withText('testModel'));
+  await t.expect(utils.inputFieldExample.hasAttribute('disabled')).ok();
+
+  await t.click(utils.saveFieldBtn);
+
+  const testModelField = Selector('tr.treegrid-body-row').withText('testModel');
+  const testSecondModelField = Selector('tr.treegrid-body-row').withText('testSecondModel');
+  const testThirdModelField = Selector('tr.treegrid-body-row').withText('testThirdModel');
+  const nestedRows = await Selector('tr.treegrid-body-row').withText('testProperty');
+  const nestedModelRows = await Selector('tr.treegrid-body-row').withText('nestedModel');
+  const editedNestedModelRows = await Selector('tr.treegrid-body-row').withText(
+    'editedNestedModel'
+  );
+
+  await t
+    .expect(Selector('tr.treegrid-body-row').count)
+    .eql(initialRowCount + 6)
+    .expect(testModelField.exists)
+    .eql(true)
+    .expect(testSecondModelField.exists)
+    .eql(true)
+    .expect(testThirdModelField.exists)
+    .eql(true)
+    .expect(nestedRows.exists)
+    .eql(true)
+    .expect(nestedRows.count)
+    .eql(3)
+    .expect(nestedModelRows.exists)
+    .eql(true)
+    .expect(nestedModelRows.count)
+    .eql(1)
+    .expect(editedNestedModelRows.exists)
+    .eql(true)
+    .expect(editedNestedModelRows.count)
+    .eql(2);
+});
+
+test('Edit a primitive child field of a prior nested model and add a new model using the prior nested model with the child edits', async t => {
+  await addNewNestedModelAtRoot(t);
+  await addNewFieldsToParentModel(t);
+  // Save the container model
+  await t.click(utils.saveModelBtn);
+  const initialRowCount = await Selector('tr.treegrid-body-row').count;
+  // Add a new field based on previous model
+  await t.click(utils.addNewFieldBtn);
+
+  await t.typeText(utils.inputFieldName, 'testSecondModel');
+  await t.click(utils.inputType).click(Selector('li').withText('testModel'));
+  await t.expect(utils.inputFieldExample.hasAttribute('disabled')).ok();
+
+  await t.click(utils.saveFieldBtn);
+
+  // Edit the primitive nested field of the original model from the root and save
+  const objectRowToEdit = Selector('tr.treegrid-body-row').withText('newTestProperty');
+  const editFieldBtn = objectRowToEdit.find('.edit-action');
+  await t.click(editFieldBtn);
+
+  await t.expect(utils.inputFieldName.value).eql('newTestProperty');
+  await t.expect(utils.inputFieldExample.value).eql('2019-01-01T18:14:29Z');
+  await t.expect(utils.inputType.getVue(({ props }) => props.value.displayName)).eql('DateTime');
+
+  await t.typeText(utils.inputFieldName, 'editedNewTestProperty', { replace: true });
+  await t.click(utils.inputType).click(Selector('li').withText('Integer'));
+
+  await t.click(utils.saveFieldBtn);
+
+  // Add a third field based on the previous model
+  await t.click(utils.addNewFieldBtn);
+
+  await t.typeText(utils.inputFieldName, 'testThirdModel');
+  await t.click(utils.inputType).click(Selector('li').withText('testModel'));
+  await t.expect(utils.inputFieldExample.hasAttribute('disabled')).ok();
+
+  await t.click(utils.saveFieldBtn);
+
+  const testModelField = Selector('tr.treegrid-body-row').withText('testModel');
+  const testSecondModelField = Selector('tr.treegrid-body-row').withText('testSecondModel');
+  const testThirdModelField = Selector('tr.treegrid-body-row').withText('testThirdModel');
+  const nestedRows = await Selector('tr.treegrid-body-row').withText('testProperty');
+  const nestedModelRows = await Selector('tr.treegrid-body-row').withText('nestedModel');
+  const newTestPropertyRows = await Selector('tr.treegrid-body-row').withText('newTestProperty');
+  const editedNewTestPropertyRows = await Selector('tr.treegrid-body-row').withText(
+    'editedNewTestProperty'
+  );
+
+  await t
+    .expect(Selector('tr.treegrid-body-row').count)
+    .eql(initialRowCount + 8)
+    .expect(testModelField.exists)
+    .eql(true)
+    .expect(testSecondModelField.exists)
+    .eql(true)
+    .expect(testThirdModelField.exists)
+    .eql(true)
+    .expect(nestedRows.exists)
+    .eql(true)
+    .expect(nestedRows.count)
+    .eql(3)
+    .expect(nestedModelRows.exists)
+    .eql(true)
+    .expect(nestedModelRows.count)
+    .eql(3)
+    .expect(newTestPropertyRows.exists)
+    .eql(true)
+    .expect(newTestPropertyRows.count)
+    .eql(1)
+    .expect(editedNewTestPropertyRows.exists)
+    .eql(true)
+    .expect(editedNewTestPropertyRows.count)
+    .eql(2);
 });

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedArrayModelField.e2e.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedArrayModelField.e2e.js
@@ -1140,3 +1140,57 @@ test('Edit a primitive child field of a prior nested model and add a new model u
     .expect(editedNewTestPropertyRows.count)
     .eql(2);
 });
+
+test('Options should be updated after editing multiple nested object names', async t => {
+  await addNewNestedModelAtRoot(t);
+  const initialRowCount = await Selector('tr.treegrid-body-row').count;
+
+  const objectRowToEdit = Selector('tr.treegrid-body-row').withText('testModel');
+  const editFieldBtn = objectRowToEdit.find('.edit-action');
+  await t.click(editFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('testModel');
+
+  await t.typeText(utils.modelName, 'editTestModel', { replace: true });
+
+  const nestedModelRowToEdit = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('nestedModel');
+  const nestedModelEditFieldBtn = nestedModelRowToEdit.find('.edit-action');
+  await t.click(nestedModelEditFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('nestedModel');
+
+  await t.typeText(utils.modelName, 'editNestedModel', { replace: true });
+
+  const nestedPropertyRowToEdit = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('testProperty');
+  const nestedPropertyEditFieldBtn = nestedPropertyRowToEdit.find('.edit-action');
+  await t.click(nestedPropertyEditFieldBtn);
+
+  await t.expect(utils.inputFieldName.value).eql('testProperty');
+
+  await t.typeText(utils.inputFieldName, 'editTestProperty', { replace: true });
+
+  // Save the nested property
+  await t.click(utils.saveFieldBtn);
+  // Save the nested model
+  await t.click(utils.saveModelBtn);
+  // Save the parent model
+  await t.click(utils.saveModelBtn);
+
+  await t.click(utils.addNewFieldBtn);
+
+  await t.click(utils.inputType).click(Selector('li').withText('editTestModel'));
+  await t
+    .expect(utils.inputType.getVue(({ props }) => props.value.displayName))
+    .eql('editTestModel');
+
+  await t.click(utils.inputType).click(Selector('li').withText('editNestedModel'));
+  await t
+    .expect(utils.inputType.getVue(({ props }) => props.value.displayName))
+    .eql('editNestedModel');
+
+  await t.expect(Selector('tr.treegrid-body-row').count).eql(initialRowCount);
+});

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
@@ -744,6 +744,58 @@ test('Cancel edits to a nested field in the model', async t => {
     .eql(false);
 });
 
+test('Parent model name edits persist after opening a field modal', async t => {
+  await addNewNestedModelAtRoot(t);
+
+  const rowToEdit = Selector('tr.treegrid-body-row').withText('testModel');
+  const editFieldBtn = rowToEdit.find('.edit-action');
+  await t.click(editFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('testModel');
+
+  // Edit the model name
+  await t.typeText(utils.modelName, 'testModelEdits', { replace: true });
+
+  const nestedFieldRowToEdit = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('testProperty');
+  const nestedFieldEditFieldBtn = nestedFieldRowToEdit.find('.edit-action');
+  await t.click(nestedFieldEditFieldBtn);
+
+  await t.expect(utils.inputFieldName.value).eql('testProperty');
+  await t.expect(utils.inputFieldExample.value).eql('123');
+  await t.expect(utils.inputType.getVue(({ props }) => props.value.displayName)).eql('Integer');
+
+  await t.click(utils.cancelFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('testModelEdits');
+});
+
+test('Parent model name edits persist after opening a model modal', async t => {
+  await addNewNestedModelAtRoot(t);
+
+  const rowToEdit = Selector('tr.treegrid-body-row').withText('testModel');
+  const editFieldBtn = rowToEdit.find('.edit-action');
+  await t.click(editFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('testModel');
+
+  // Edit the model name
+  await t.typeText(utils.modelName, 'testModelEdits', { replace: true });
+
+  const nestedModelRowToEdit = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('nestedModel');
+  const nestedModelEditFieldBtn = nestedModelRowToEdit.find('.edit-action');
+  await t.click(nestedModelEditFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('nestedModel');
+
+  await t.click(utils.cancelModelBtn);
+
+  await t.expect(utils.modelName.value).eql('testModelEdits');
+});
+
 test('Cancel add new model to an already nested model', async t => {
   await addNewNestedModelAtRoot(t);
   const initialRowCount = await Selector('tr.treegrid-body-row').count;

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
@@ -1138,3 +1138,57 @@ test('Edit a primitive child field of a prior nested model and add a new model u
     .expect(editedNewTestPropertyRows.count)
     .eql(2);
 });
+
+test('Options should be updated after editing multiple nested object names', async t => {
+  await addNewNestedModelAtRoot(t);
+  const initialRowCount = await Selector('tr.treegrid-body-row').count;
+
+  const objectRowToEdit = Selector('tr.treegrid-body-row').withText('testModel');
+  const editFieldBtn = objectRowToEdit.find('.edit-action');
+  await t.click(editFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('testModel');
+
+  await t.typeText(utils.modelName, 'editTestModel', { replace: true });
+
+  const nestedModelRowToEdit = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('nestedModel');
+  const nestedModelEditFieldBtn = nestedModelRowToEdit.find('.edit-action');
+  await t.click(nestedModelEditFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('nestedModel');
+
+  await t.typeText(utils.modelName, 'editNestedModel', { replace: true });
+
+  const nestedPropertyRowToEdit = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('testProperty');
+  const nestedPropertyEditFieldBtn = nestedPropertyRowToEdit.find('.edit-action');
+  await t.click(nestedPropertyEditFieldBtn);
+
+  await t.expect(utils.inputFieldName.value).eql('testProperty');
+
+  await t.typeText(utils.inputFieldName, 'editTestProperty', { replace: true });
+
+  // Save the nested property
+  await t.click(utils.saveFieldBtn);
+  // Save the nested model
+  await t.click(utils.saveModelBtn);
+  // Save the parent model
+  await t.click(utils.saveModelBtn);
+
+  await t.click(utils.addNewFieldBtn);
+
+  await t.click(utils.inputType).click(Selector('li').withText('editTestModel'));
+  await t
+    .expect(utils.inputType.getVue(({ props }) => props.value.displayName))
+    .eql('editTestModel');
+
+  await t.click(utils.inputType).click(Selector('li').withText('editNestedModel'));
+  await t
+    .expect(utils.inputType.getVue(({ props }) => props.value.displayName))
+    .eql('editNestedModel');
+
+  await t.expect(Selector('tr.treegrid-body-row').count).eql(initialRowCount);
+});

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/NestedModelField.e2e.js
@@ -796,6 +796,51 @@ test('Parent model name edits persist after opening a model modal', async t => {
   await t.expect(utils.modelName.value).eql('testModelEdits');
 });
 
+test('Parent model name edits persist after edits to a nested model', async t => {
+  await addNewNestedModelAtRoot(t);
+
+  const rowToEdit = Selector('tr.treegrid-body-row').withText('testModel');
+  const editFieldBtn = rowToEdit.find('.edit-action');
+  await t.click(editFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('testModel');
+
+  // Edit the model name
+  await t.typeText(utils.modelName, 'testModelEdits', { replace: true });
+
+  const nestedModelRowToEdit = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('nestedModel');
+  const nestedModelEditFieldBtn = nestedModelRowToEdit.find('.edit-action');
+  await t.click(nestedModelEditFieldBtn);
+
+  await t.expect(utils.modelName.value).eql('nestedModel');
+
+  // Edit the child model name
+  await t.typeText(utils.modelName, 'editedNestedModel', { replace: true });
+  const childModelFieldRowToEdit = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('testProperty');
+  const nestedFieldEditFieldBtn = childModelFieldRowToEdit.find('.edit-action');
+  await t.click(nestedFieldEditFieldBtn);
+
+  await t.expect(utils.inputFieldName.value).eql('testProperty');
+  await t.expect(utils.inputFieldExample.value).eql('123');
+  await t.expect(utils.inputType.getVue(({ props }) => props.value.displayName)).eql('Integer');
+
+  await t.click(utils.cancelFieldBtn);
+
+  await t.click(utils.saveModelBtn);
+
+  await t.expect(nestedModelRowToEdit.exists).eql(false);
+
+  const editedNestedModelRow = Selector('#nestedContractGrid')
+    .find('tr.treegrid-body-row')
+    .withText('editedNestedModel');
+  await t.expect(editedNestedModelRow.exists).eql(true);
+  await t.expect(utils.modelName.value).eql('testModelEdits');
+});
+
 test('Cancel add new model to an already nested model', async t => {
   await addNewNestedModelAtRoot(t);
   const initialRowCount = await Selector('tr.treegrid-body-row').count;


### PR DESCRIPTION
- Added conditions to close and showFieldWindow to keep the edited model name. Added a parentName property to keep track of the changed parent name for a child field.
- Added two e2e tests to check if the model name edits persists when a child field or a child model modal is opened.