### PR TITLE
Feature/#38 add javascript tests to build

### DIFF
--- a/src/Totem/package.json
+++ b/src/Totem/package.json
@@ -4,7 +4,7 @@
   "description": "Contract Testing for Distributed Systems",
   "main": "ClientApp/app.js",
   "scripts": {
-    "runtestps": "@powershell start 'dotnet' -nnw -argumentlist 'run -p ../Totem/Totem.csproj --launch-profile \"Testing\"'",
+    "runtestps": "@powershell start 'dotnet' -argumentlist 'run -p ../Totem/Totem.csproj --launch-profile \"Testing\"'",
     "killapp": "@powershell taskkill /f /im dotnet.exe",
     "runtest": "webpack && npm run --silent runtestps",
     "e2etest": "testcafe 'chrome:headless' ./ClientApp/features/contracts/__tests__/e2e/*.e2e.js",


### PR DESCRIPTION
- Removed concurrently package and used npm-run-all instead to avoid npm errors on success. 
- Added "killapp" to kill the dotnet process after testing. 
- Refactored e2e by splitting into smaller scripts. 
- Added "Javascript Test" task to the buld process.Added husky to facilitate with adding git hooks. Added a pre-push hook to run js tests.
- Removed the -nnw (No New Window) switch to allow both the terminals (localhost server and test output) to be visible.