### PR TITLE
Feature/#11 import contract from sample message

### DIFF
--- a/src/Totem/ClientApp/App.vue
+++ b/src/Totem/ClientApp/App.vue
@@ -477,12 +477,17 @@ export default {
     importContract() {
       const message = $('#import-message')[0].value;
       const contractBasedOnMessage = buildContractFromMessage(message);
-      $('#ModifiedContract_ContractString')[0].value = JSON.stringify(contractBasedOnMessage);
       this.rows = parseContractArray(
         JSON.stringify(contractBasedOnMessage),
         'contract-string-validation'
       );
+      $('#contract-raw')[0].value = JSON.stringify(contractBasedOnMessage, null, 2);
+      $('#ModifiedContract_ContractString')[0].value = JSON.stringify(contractBasedOnMessage);
       this.closeModal('importContract');
+      if (typeof setSaveButton === 'function') {
+        // setSaveButton is defined in Edit.cshtml
+        setSaveButton(); // eslint-disable-line no-undef
+      }
       $('#contract-raw').scrollTop(0);
     },
 

--- a/src/Totem/ClientApp/App.vue
+++ b/src/Totem/ClientApp/App.vue
@@ -4,8 +4,6 @@
       id="rootGrid"
       ref="rootContractGrid"
       :rows="rows"
-      :hide-ellipsis-menu="false"
-      :edit-stack="editStack"
       @editManually="showEditManuallyWindow"
       @importFromMessage="showImportWindow"
       @showFieldWindow="showFieldWindow(...arguments)"

--- a/src/Totem/ClientApp/App.vue
+++ b/src/Totem/ClientApp/App.vue
@@ -7,6 +7,7 @@
       :hide-ellipsis-menu="false"
       :edit-stack="editStack"
       @editManually="showEditManuallyWindow"
+      @importFromMessage="showImportWindow"
       @showFieldWindow="showFieldWindow(...arguments)"
       @showModelWindow="showModelWindow(...arguments)"
     />
@@ -16,6 +17,12 @@
       :contract-string="modifiedContract"
       @close="closeModal('editManually')"
       @updateData="updateContractManually"
+    />
+    <BuildContractFromMessageModalWindow
+      v-show="isImportWindowVisible"
+      title="Import Contract"
+      @close="closeModal('importContract')"
+      @importContract="importContract"
     />
     <AddModelModalWindow
       v-show="isAddModelWindowVisible"
@@ -51,6 +58,7 @@
 import $ from 'jquery';
 import _ from 'lodash';
 import EditContractModalWindow from './features/contracts/EditContractModalWindow.vue';
+import BuildContractFromMessageModalWindow from './features/contracts/BuildContractFromMessageModalWindow.vue';
 import AddNewFieldModalWindow from './features/contracts/AddNewFieldModalWindow.vue';
 import AddModelModalWindow from './features/contracts/AddModelModalWindow.vue';
 import ContractGrid from './features/contracts/ContractGrid.vue';
@@ -64,7 +72,8 @@ import {
   getPropertiesCopy,
   isObjectArray,
   updateProperties,
-  hasProperties
+  hasProperties,
+  buildContractFromMessage
 } from './features/contracts/contractParser';
 import {
   reorderOptions,
@@ -80,6 +89,7 @@ export default {
   components: {
     ContractGrid,
     EditContractModalWindow,
+    BuildContractFromMessageModalWindow,
     AddModelModalWindow,
     AddNewFieldModalWindow
   },
@@ -96,6 +106,7 @@ export default {
       isEditManuallyWindowVisible: false,
       isAddFieldWindowVisible: false,
       isAddModelWindowVisible: false,
+      isImportWindowVisible: false,
       disableDelete: false
     };
   },
@@ -144,7 +155,15 @@ export default {
     showEditManuallyWindow() {
       this.isAddFieldWindowVisible = false;
       this.isAddModelWindowVisible = false;
+      this.isImportWindowVisible = false;
       this.isEditManuallyWindowVisible = true;
+    },
+
+    showImportWindow() {
+      this.isAddFieldWindowVisible = false;
+      this.isAddModelWindowVisible = false;
+      this.isEditManuallyWindowVisible = false;
+      this.isImportWindowVisible = true;
     },
 
     showFieldWindow(field) {
@@ -176,6 +195,7 @@ export default {
         this.editStack.push({ parentId: null });
       }
       this.isEditManuallyWindowVisible = false;
+      this.isImportWindowVisible = false;
       this.isAddFieldWindowVisible = true;
     },
 
@@ -209,6 +229,7 @@ export default {
       this.editStack.push(deepCopy(model));
       this.modalRows = getPropertiesCopy(model);
       this.isEditManuallyWindowVisible = false;
+      this.isImportWindowVisible = false;
       this.isAddFieldWindowVisible = false;
       this.isAddModelWindowVisible = true;
     },
@@ -216,6 +237,8 @@ export default {
     closeModal(modal, alreadyAdjusted = false, setDescendingFalse = false) {
       if (modal === 'editManually') {
         this.isEditManuallyWindowVisible = false;
+      } else if (modal === 'importContract') {
+        this.isImportWindowVisible = false;
       } else if (modal === 'addField') {
         if (this.editStack.length > 0 && !alreadyAdjusted) {
           this.editStack.pop();
@@ -453,6 +476,18 @@ export default {
       $('#contract-raw').scrollTop(0);
     },
 
+    importContract() {
+      const message = $('#import-message')[0].value;
+      const contractBasedOnMessage = buildContractFromMessage(message);
+      $('#ModifiedContract_ContractString')[0].value = JSON.stringify(contractBasedOnMessage);
+      this.rows = parseContractArray(
+        JSON.stringify(contractBasedOnMessage),
+        'contract-string-validation'
+      );
+      this.closeModal('importContract');
+      $('#contract-raw').scrollTop(0);
+    },
+
     updateSaveButtonState() {
       /* eslint-disable */
       if (typeof setSaveButton === 'function') {
@@ -465,6 +500,6 @@ export default {
       }
       /* eslint-enable */
     }
-  }
+  }	
 };
 </script>

--- a/src/Totem/ClientApp/App.vue
+++ b/src/Totem/ClientApp/App.vue
@@ -503,6 +503,6 @@ export default {
       }
       /* eslint-enable */
     }
-  }	
+  }
 };
 </script>

--- a/src/Totem/ClientApp/features/contracts/AddModelModalWindow.vue
+++ b/src/Totem/ClientApp/features/contracts/AddModelModalWindow.vue
@@ -34,7 +34,7 @@
           id="nestedContractGrid"
           :rows="objectRows"
           :is-ellipsis-menu-visible="false"
-          @hideEllipsisMenu="true"
+          :is-import-button-visible="false"
           @showModelWindow="showModelWindow(...arguments)"
           @showFieldWindow="showFieldWindow(...arguments)"
           @editManually="this.$emit('showEditManuallyWindow')"

--- a/src/Totem/ClientApp/features/contracts/BuildContractFromMessageModalWindow.vue
+++ b/src/Totem/ClientApp/features/contracts/BuildContractFromMessageModalWindow.vue
@@ -1,0 +1,57 @@
+<template>
+  <ModalWindow
+    ref="buildContractFromMessageModalWindow"
+    title="Import Contract From Message"
+    :success-btn="{
+      id: 'importContract',
+      text: 'Import Contract',
+      clicked: importContract
+    }"
+    :cancel-btn="{
+      id: 'cancelBtn',
+      text: 'Cancel',
+      clicked: close
+    }"
+  >
+    <template v-slot:body>
+      <textarea id="import-message" v-model="message" class="form-control tall mono" />
+    </template>
+  </ModalWindow>
+</template>
+
+<script>
+import $ from 'jquery';
+import ModalWindow from '../../components/ModalWindow.vue';
+import { isValidJSON } from './dataHelpers';
+
+export default {
+  name: 'BuildContractFromMessageModalWindow',
+  components: {
+    ModalWindow
+  },
+  props: {
+    title: { type: String, default: '' }
+  },
+  data() {
+    return {
+      message: ''
+    };
+  },
+  methods: {
+    importContract() {
+      const validationFieldId = 'contract-string-validation';
+      const $validationField = $(`#${validationFieldId}`);
+      if (isValidJSON($('#import-message')[0].value, $validationField)) {
+        this.$emit('importContract');
+      } else {
+        this.$emit('close');
+      }
+    },
+    close() {
+      $('#import-message')[0].value = '';
+      this.$emit('close');
+      $('#import-message').scrollTop(0);
+    }
+  }
+};
+</script>

--- a/src/Totem/ClientApp/features/contracts/BuildContractFromMessageModalWindow.vue
+++ b/src/Totem/ClientApp/features/contracts/BuildContractFromMessageModalWindow.vue
@@ -39,11 +39,11 @@ export default {
   },
   methods: {
     importContract() {
-      const validationFieldId = 'contract-string-validation';
-      const $validationField = $(`#${validationFieldId}`);
-      if (isValidJSON($('#import-message')[0].value, $validationField)) {
+      if (isValidJSON($('#import-message')[0].value)) {
         this.$emit('importContract');
       } else {
+        const $validationField = $(`#contract-string-validation`);
+        $validationField.html('Invalid JSON');
         this.$emit('close');
       }
     },

--- a/src/Totem/ClientApp/features/contracts/ContractGrid.vue
+++ b/src/Totem/ClientApp/features/contracts/ContractGrid.vue
@@ -11,7 +11,9 @@
         <i v-if="scope.row.isLocked" class="fas edit fa-lock" />
         <i v-else class="fas edit fa-pencil-alt" />
       </template>
-      <template slot="typeTemplate" slot-scope="scope">{{ getType(scope.row) }}</template>
+      <template slot="typeTemplate" slot-scope="scope">
+        {{ getType(scope.row) }}
+      </template>
     </TreeGrid>
   </div>
 </template>

--- a/src/Totem/ClientApp/features/contracts/ContractGrid.vue
+++ b/src/Totem/ClientApp/features/contracts/ContractGrid.vue
@@ -31,6 +31,10 @@ export default {
     isEllipsisMenuVisible: {
       type: Boolean,
       default: true
+    },
+    isImportButtonVisible: {
+      type: Boolean,
+      default: true
     }
   },
   data() {
@@ -92,15 +96,17 @@ export default {
         ) : (
           /* eslint-disable */
           <div class="btn-group">
-            <button
-              id="importContractFromMessageBtn"
-              class="ui-button btn grid-btn"
-              onClick={this.showImportModal}
-              type="button"
-            >
-              <i class="fa fa-upload" />
-              Import
-            </button>
+            {this.isImportButtonVisible && (
+              <button
+                id="importContractFromMessageBtn"
+                class="ui-button btn grid-btn"
+                onClick={this.showImportModal}
+                type="button"
+              >
+                <i class="fa fa-upload" />
+                Import
+              </button>
+            )}
             <button
               id="addNewFieldBtn"
               class="ui-button btn grid-btn"

--- a/src/Totem/ClientApp/features/contracts/ContractGrid.vue
+++ b/src/Totem/ClientApp/features/contracts/ContractGrid.vue
@@ -6,8 +6,6 @@
       :columns="columns"
       :menu="menu"
       @editRowClick="handleEditClick"
-      @editManually="$emit('editManually')"
-      @showFieldWindow="$emit('showFieldWindow')"
     >
       <template slot="editableTemplate" slot-scope="scope">
         <i v-if="scope.row.isLocked" class="fas edit fa-lock" />
@@ -77,6 +75,9 @@ export default {
     showAddNewFieldModal() {
       this.$emit('showFieldWindow');
     },
+    showImportModal() {
+      this.$emit('importFromMessage');
+    },
     getType(property) {
       return getDisplayType(property);
     },
@@ -91,6 +92,15 @@ export default {
         ) : (
           /* eslint-disable */
           <div class="btn-group">
+            <button
+              id="importContractFromMessageBtn"
+              class="ui-button btn grid-btn"
+              onClick={this.showImportModal}
+              type="button"
+            >
+              <i class="fa fa-upload" />
+              Import
+            </button>
             <button
               id="addNewFieldBtn"
               class="ui-button btn grid-btn"

--- a/src/Totem/ClientApp/features/contracts/__tests__/BuildContractFromMessageModalWindow.spec.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/BuildContractFromMessageModalWindow.spec.js
@@ -1,0 +1,34 @@
+import { mount } from '@vue/test-utils';
+import sinon from 'sinon';
+import BuildContractFromMessageModalWindow from '../BuildContractFromMessageModalWindow.vue';
+
+describe('BuildContractFromMessageModalWindow.vue', () => {
+  const wrapper = mount(BuildContractFromMessageModalWindow, {
+    propsData: {
+      title: 'Test Import Contract'
+    }
+  });
+  const importContractStub = sinon.stub();
+  const closeStub = sinon.stub();
+
+  wrapper.setMethods({
+    importContract: importContractStub,
+    close: closeStub
+  });
+
+  test('is a Vue instance', () => {
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('calls importContract on import button click', () => {
+    const importButton = wrapper.find('#importContract');
+    importButton.trigger('click');
+    expect(importContractStub.called).toBe(true);
+  });
+
+  it('calls close on close button click', () => {
+    const closeButton = wrapper.find('#cancelBtn');
+    closeButton.trigger('click');
+    expect(closeStub.called).toBe(true);
+  });
+});

--- a/src/Totem/ClientApp/features/contracts/__tests__/contractParser.spec.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/contractParser.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import {
   parseContractArray,
   formatReferenceName,
@@ -10,7 +11,8 @@ import {
   getPropertiesCopy,
   hasProperties,
   isObjectArray,
-  updateProperties
+  updateProperties,
+  buildContractFromMessage
 } from '../contractParser';
 
 const sampleContractString = `{
@@ -938,5 +940,104 @@ describe('updateProperties', () => {
 
     expect(model.properties).toEqual(expectedProperties);
     expect(model.items).toEqual(undefined);
+  });
+});
+
+describe('buildContractFromMessage', () => {
+  it('should generate a contract based on a message', () => {
+    const messageString = `{
+      "item1": "test1",
+      "item2": "test2",
+      "item3": "test3"
+    }`;
+
+    const result = buildContractFromMessage(messageString);
+
+    const expectedProperties = {
+      item1: {
+        type: 'string',
+        example: 'sample string'
+      },
+      item2: {
+        type: 'string',
+        example: 'sample string'
+      },
+      item3:  {
+        type: 'string',
+        example: 'sample string'
+      }
+    };
+
+    expect(result.Contract.type).toEqual('object');
+    expect(result.Contract.properties).toEqual(expectedProperties);
+  });
+
+  it('should handle nested objects', () => {
+    const messageString = `{
+      "item1": "test",
+      "item2": {
+        "item3": "test543",
+        "item4": {
+          "item5": "testu436"
+        }
+      }
+    }`;
+
+    const result = buildContractFromMessage(messageString);
+
+    const expectedProperties = {
+      item1: {
+        type: 'string',
+        example: 'sample string'
+      },
+      item2: {
+        type: 'object',
+        properties: {
+          item3:  {
+            type: 'string',
+            example: 'sample string'
+          },
+          item4:  {
+            type: 'object',
+            properties: {
+              item5:  {
+                type: 'string',
+                example: 'sample string'
+              }
+            }
+          }
+        }
+      },
+    };
+
+    expect(result.Contract.type).toEqual('object');
+    expect(result.Contract.properties).toEqual(expectedProperties);
+  });
+
+  it('should handle arrays', () => {
+    const messageString = `{
+      "item1": "test",
+      "item2": ["string1", "string2"]
+    }`;
+
+    const result = buildContractFromMessage(messageString);
+
+    const expectedProperties = {
+      item1: {
+        type: 'string',
+        example: 'sample string'
+      },
+      item2: {
+        type: 'array',
+        items: {
+          type: 'string',
+          example: 'sample string'
+        },
+        example: '["sample string"]'
+      }
+    };
+
+    expect(result.Contract.type).toEqual('object');
+    expect(result.Contract.properties).toEqual(expectedProperties);
   });
 });

--- a/src/Totem/ClientApp/features/contracts/__tests__/dataHelpers.spec.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/dataHelpers.spec.js
@@ -5,7 +5,8 @@ import {
   findRowInTreeAndUpdate,
   last,
   findRowInTreeAndDelete,
-  findParent
+  findParent,
+  isValidJSON
 } from '../dataHelpers';
 
 describe('Reorder Options', () => {
@@ -211,5 +212,27 @@ describe('last', () => {
     const array = [];
     const item = last(array);
     expect(item).toBe(undefined);
+  });
+});
+
+describe('isValidJSON', () => {
+  it('returns true when string is valid JSON', () => {
+    const testString = `{
+      "item1": "test",
+      "item2": {
+        "item3": "test543",
+        "item4": {
+          "item5": "testu436"
+        }
+      }
+    }`;
+    const result = isValidJSON(testString);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when string is valid JSON', () => {
+    const testString = 'invalid string';
+    const result = isValidJSON(testString);
+    expect(result).toBe(false);
   });
 });

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/ImportContract.e2e.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/ImportContract.e2e.js
@@ -1,0 +1,105 @@
+import { Selector } from 'testcafe';
+import { baseUrl } from '../../../../testConfig/setup';
+import * as utils from './e2e-utils';
+
+global
+  .fixture('Import Contract Test')
+  .page(baseUrl)
+  .beforeEach(utils.loginAndNavigateToEditContract)
+  .afterEach(utils.logOut);
+
+test('Import a non-nested contract', async t => {
+  await t.click(utils.importContractBtn);
+
+  await t.expect(utils.importTextArea.value).eql('');
+
+  const messageString = `{
+    "item1": "test1",
+    "item2": "test2",
+    "item3": "test3"
+  }`;
+  await t.typeText(utils.importTextArea, messageString, { replace: true });
+  await t.click(utils.importBtn);
+
+  const item1Row = Selector('tr.treegrid-body-row').withText('item1');
+  const item2Row = Selector('tr.treegrid-body-row').withText('item2');
+  const item3Row = Selector('tr.treegrid-body-row').withText('item3');
+
+  await t
+    .expect(Selector('tr.treegrid-body-row').count)
+    .eql(3)
+    .expect(item1Row.exists)
+    .eql(true)
+    .expect(item2Row.exists)
+    .eql(true)
+    .expect(item3Row.exists)
+    .eql(true);
+});
+
+test('Import a nested contract', async t => {
+  await t.click(utils.importContractBtn);
+
+  await t.expect(utils.importTextArea.value).eql('');
+
+  const messageString = `{
+    "item1": "test",
+    "item2": {
+      "item3": "test543",
+      "item4": {
+        "item5": "testu436"
+      }
+    }
+  }`;
+  await t.typeText(utils.importTextArea, messageString, { replace: true });
+  await t.click(utils.importBtn);
+
+  const item1Row = Selector('tr.treegrid-body-row').withText('item1');
+  const item2Row = Selector('tr.treegrid-body-row').withText('item2');
+  const item3Row = Selector('tr.treegrid-body-row').withText('item3');
+  const item4Row = Selector('tr.treegrid-body-row').withText('item4');
+  const item5Row = Selector('tr.treegrid-body-row').withText('item5');
+
+  await t
+    .expect(Selector('tr.treegrid-body-row').count)
+    .eql(5)
+    .expect(item1Row.exists)
+    .eql(true)
+    .expect(item2Row.exists)
+    .eql(true)
+    .expect(item2Row.textContent)
+    .contains('object')
+    .expect(item3Row.exists)
+    .eql(true)
+    .expect(item4Row.exists)
+    .eql(true)
+    .expect(item4Row.textContent)
+    .contains('object')
+    .expect(item5Row.exists)
+    .eql(true);
+});
+
+test('Import a contract with array', async t => {
+  await t.click(utils.importContractBtn);
+
+  await t.expect(utils.importTextArea.value).eql('');
+
+  const messageString = `{
+    "item1": "test",
+    "item2": ["string1", "string2"]
+  }`;
+  await t.typeText(utils.importTextArea, messageString, { replace: true });
+  await t.click(utils.importBtn);
+
+  const item1Row = Selector('tr.treegrid-body-row').withText('item1');
+  const item2Row = Selector('tr.treegrid-body-row').withText('item2');
+
+  await t
+    .expect(Selector('tr.treegrid-body-row').count)
+    .eql(2)
+    .expect(item1Row.exists)
+    .eql(true)
+    .expect(item2Row.exists)
+    .eql(true)
+    .expect(item2Row.textContent)
+    .contains('array (string)');
+});

--- a/src/Totem/ClientApp/features/contracts/__tests__/e2e/e2e-utils.js
+++ b/src/Totem/ClientApp/features/contracts/__tests__/e2e/e2e-utils.js
@@ -19,6 +19,11 @@ export const saveModelBtn = Selector('#saveModelBtn');
 export const cancelModelBtn = Selector('#modelModalWindow').find('#cancelBtn');
 export const addNewFieldNestedBtn = Selector('#nestedContractGrid').find('#addNewFieldBtn');
 
+// Import Contract buttons
+export const importContractBtn = Selector('#importContractFromMessageBtn');
+export const importBtn = Selector('#importContract');
+export const importTextArea = Selector('#import-message');
+
 // Fixture Setup: Login and Go to Edit
 export async function loginAndNavigateToEditContract(t) {
   const goToLoginButton = Selector('#loginBtn');

--- a/src/Totem/ClientApp/features/contracts/contractParser.js
+++ b/src/Totem/ClientApp/features/contracts/contractParser.js
@@ -91,7 +91,17 @@ export const findRow = (rowId, rows) => {
 export const buildPropertiesFromMessage = (parentObject, messageObject) => {
   const updatedParentObject = deepCopy(parentObject);
   Object.keys(messageObject).forEach(key => {
-    if (messageObject[key] instanceof Object) {
+    if (Array.isArray(messageObject[key])) {
+      const prop = {
+        type: 'array',
+        example: '["sample string"]',
+        items: {
+          type: 'string',
+          example: 'sample string'
+        }
+      };
+      updatedParentObject.properties[key] = prop;
+    } else if (messageObject[key] instanceof Object) {
       const prop = {
         type: 'object',
         properties: {}
@@ -103,7 +113,8 @@ export const buildPropertiesFromMessage = (parentObject, messageObject) => {
       );
     } else {
       const prop = {
-        type: 'string'
+        type: 'string',
+        example: 'sample string'
       };
       updatedParentObject.properties[key] = prop;
     }
@@ -249,10 +260,10 @@ export const isObjectArray = schema => {
 export const updateProperties = (schema, properties, isArray) => {
   /* eslint-disable */
   if (properties === undefined) {
-    properties = getPropertiesCopy(schema);
+    updatedProperties = getPropertiesCopy(schema);
   }
   if (isArray === undefined) {
-    isArray = isObjectArray(schema);
+    updatedIsArray = isObjectArray(schema);
   }
   schema.properties = isArray ? undefined : properties;
   schema.items = isArray ? { type: 'object', properties } : undefined;

--- a/src/Totem/ClientApp/features/contracts/contractParser.js
+++ b/src/Totem/ClientApp/features/contracts/contractParser.js
@@ -87,6 +87,24 @@ export const findRow = (rowId, rows) => {
   return result;
 };
 
+/* buildContractFromMessage: build a contract from the given message */
+export const buildContractFromMessage = message => {
+  const messageObject = JSON.parse(message);
+  const baseContractObject = {
+    Contract: {
+      type: 'object',
+      properties: {}
+    }
+  };
+  Object.keys(messageObject).forEach(key => {
+    const prop = {
+      type: 'string'
+    };
+    baseContractObject.Contract.properties[key] = prop;
+  });
+  return baseContractObject;
+};
+
 /* updateNestedProperty: finds the existing row by rowId and replaces it with the edited value */
 export const updateNestedProperty = (editedRow, rows, isDelete) => {
   const updatedRows = deepCopy(rows);

--- a/src/Totem/ClientApp/features/contracts/contractParser.js
+++ b/src/Totem/ClientApp/features/contracts/contractParser.js
@@ -260,10 +260,12 @@ export const isObjectArray = schema => {
 export const updateProperties = (schema, properties, isArray) => {
   /* eslint-disable */
   if (properties === undefined) {
-    updatedProperties = getPropertiesCopy(schema);
+    // eslint-disable-next-line no-param-reassign
+    properties = getPropertiesCopy(schema);
   }
   if (isArray === undefined) {
-    updatedIsArray = isObjectArray(schema);
+    // eslint-disable-next-line no-param-reassign
+    isArray = isObjectArray(schema);
   }
   schema.properties = isArray ? undefined : properties;
   schema.items = isArray ? { type: 'object', properties } : undefined;

--- a/src/Totem/ClientApp/features/contracts/contractParser.js
+++ b/src/Totem/ClientApp/features/contracts/contractParser.js
@@ -216,6 +216,17 @@ export const createContractString = (rows, schema) => {
       newContractObject[model] = schema[model];
     }
   });
+
+  if (JSON.stringify(newContractObject).includes('#/Guid')) {
+    newContractObject.Guid = {
+      type: 'string',
+      pattern: '^(([0-9a-f]){8}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){12})$',
+      minLength: 36,
+      maxLength: 36,
+      example: '01234567-abcd-0123-abcd-0123456789ab'
+    };
+  }
+
   return JSON.stringify(newContractObject);
 };
 

--- a/src/Totem/ClientApp/features/contracts/contractParser.js
+++ b/src/Totem/ClientApp/features/contracts/contractParser.js
@@ -87,6 +87,30 @@ export const findRow = (rowId, rows) => {
   return result;
 };
 
+/* buildPropertiesFromMessage: build the properties for an object from the given message */
+export const buildPropertiesFromMessage = (parentObject, messageObject) => {
+  const updatedParentObject = deepCopy(parentObject);
+  Object.keys(messageObject).forEach(key => {
+    if (messageObject[key] instanceof Object) {
+      const prop = {
+        type: 'object',
+        properties: {}
+      };
+      updatedParentObject.properties[key] = prop;
+      updatedParentObject.properties[key] = buildPropertiesFromMessage(
+        updatedParentObject.properties[key],
+        messageObject[key]
+      );
+    } else {
+      const prop = {
+        type: 'string'
+      };
+      updatedParentObject.properties[key] = prop;
+    }
+  });
+  return updatedParentObject;
+};
+
 /* buildContractFromMessage: build a contract from the given message */
 export const buildContractFromMessage = message => {
   const messageObject = JSON.parse(message);
@@ -96,12 +120,10 @@ export const buildContractFromMessage = message => {
       properties: {}
     }
   };
-  Object.keys(messageObject).forEach(key => {
-    const prop = {
-      type: 'string'
-    };
-    baseContractObject.Contract.properties[key] = prop;
-  });
+  baseContractObject.Contract = buildPropertiesFromMessage(
+    baseContractObject.Contract,
+    messageObject
+  );
   return baseContractObject;
 };
 

--- a/src/Totem/ClientApp/features/contracts/dataHelpers.js
+++ b/src/Totem/ClientApp/features/contracts/dataHelpers.js
@@ -139,4 +139,14 @@ export const findParent = (tree, childRow) => {
   return parentRow;
 };
 
+export const isValidJSON = (msg, $validationField) => {
+  try {
+    JSON.parse(msg);
+  } catch (e) {
+    $validationField.html(e);
+    return false;
+  }
+  return true;
+};
+
 export const last = array => array[array.length - 1];

--- a/src/Totem/ClientApp/features/contracts/dataHelpers.js
+++ b/src/Totem/ClientApp/features/contracts/dataHelpers.js
@@ -139,11 +139,10 @@ export const findParent = (tree, childRow) => {
   return parentRow;
 };
 
-export const isValidJSON = (msg, $validationField) => {
+export const isValidJSON = msg => {
   try {
     JSON.parse(msg);
   } catch (e) {
-    $validationField.html(e);
     return false;
   }
   return true;

--- a/src/Totem/package-lock.json
+++ b/src/Totem/package-lock.json
@@ -7155,9 +7155,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
-      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -12958,16 +12958,23 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.1.tgz",
-      "integrity": "sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==",
+      "version": "3.6.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
+      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",


### PR DESCRIPTION
- Merged in #54 (Array UI Handling)
- Merged in #39 (Refactoring of Tree Components)
- Added a new modal window for importing contracts using messages.
- Added a datahelper method to check if a string is valid JSON and add the error to the specified validation field. Added a buildContractFromMessage to build a new contract from the given message object. Currently only strings are supported with no format support.
- Refactored to add support for import modal to allow for contracts to be imported using a message string. Added ability to show/hide the import modal and update the contract string and rows with the new contract from the message.
- Refactored buildConractMessage to use recursion in order to support nested objects.
- Added support for arrays for import and fixed lint errors for updateProperties
- Added unit tests for buildContractFromMessage. Added unit tests for isValidJSON datahelper. Added Vue component test for BuildContractFromMessageModalWindow.vue. Added e2e tests for import contract flow