### PR TITLE
Feature/#72 add support for number values in contract definitions

### DIFF
--- a/src/Totem.DatabaseMigration/Scripts/up/2019-10-10-1100.SeedNumbersInContractSchemaTable.sql
+++ b/src/Totem.DatabaseMigration/Scripts/up/2019-10-10-1100.SeedNumbersInContractSchemaTable.sql
@@ -1,0 +1,16 @@
+﻿MERGE INTO [ContractSchema] TargetTable
+USING (VALUES ('Number','{
+	"type": "number",
+	"example": "5.5"
+}','1.0'),('Number(Float)','{
+	"type": "number",
+	"format": "float",
+	"example": "10.5"
+}','1.0'),('Number(Double)','{
+	"type": "number",
+	"format": "double",
+	"example": "123456789012.34567"
+}','1.0')) AS PrimitiveTypes (SchemaName,SchemaString,VersionNumber)
+ON TargetTable.SchemaName = PrimitiveTypes.SchemaName
+WHEN NOT MATCHED THEN
+INSERT (SchemaName,SchemaString,VersionNumber) VALUES (PrimitiveTypes.SchemaName, PrimitiveTypes.SchemaString, PrimitiveTypes.VersionNumber);

--- a/src/Totem.Tests/Features/API/SampleDataTests.cs
+++ b/src/Totem.Tests/Features/API/SampleDataTests.cs
@@ -73,11 +73,9 @@ namespace Totem.Tests.Features.API
             var result = await Send(command);
 
             var messageDictionary = JsonConvert.DeserializeObject<CaseInsensitiveDictionary<object>>(result.SampleData);
-            var time = DateTime.Parse(messageDictionary["Timestamp"].ToString());
-            var guid = Guid.Parse(messageDictionary["ID"].ToString());
+            Guid.TryParse(messageDictionary["ID"].ToString(), out _).ShouldBe(true);
+            DateTime.TryParse(messageDictionary["Timestamp"].ToString(), out _).ShouldBe(true);
 
-            guid.GetType().ShouldBe(typeof(Guid));
-            time.GetType().ShouldBe(typeof(DateTime));
             messageDictionary["Name"].ShouldBe("String text");
             messageDictionary["Age"].ShouldBe(5);
         }
@@ -85,39 +83,32 @@ namespace Totem.Tests.Features.API
         public void GeneratesProperIntegerSampleData()
         {
             var sampleInt32 = SampleData.GenerateSampleData("Integer", "Int32");
-            var int32Value = int.Parse(sampleInt32);
-            int32Value.GetType().ShouldBe(typeof(int));
+            int.TryParse(sampleInt32, out _).ShouldBe(true);
 
             var sampleInt64 = SampleData.GenerateSampleData("Integer", "Int64");
-            var int64Value = long.Parse(sampleInt64);
-            int64Value.GetType().ShouldBe(typeof(long));
+            long.TryParse(sampleInt64, out _).ShouldBe(true);
 
             var sampleInt = SampleData.GenerateSampleData("Integer", null);
-            var intValue = long.Parse(sampleInt);
-            intValue.GetType().ShouldBe(typeof(long));
+            long.TryParse(sampleInt, out _).ShouldBe(true);
         }
 
         public void GeneratesProperNumberSampleData()
         {
             var sampleFloat = SampleData.GenerateSampleData("Number", "Float");
-            var floatValue = float.Parse(sampleFloat);
-            floatValue.GetType().ShouldBe(typeof(float));
+            float.TryParse(sampleFloat, out _).ShouldBe(true);
 
             var sampleDouble = SampleData.GenerateSampleData("Number", "Double");
-            var doubleValue = double.Parse(sampleDouble);
-            doubleValue.GetType().ShouldBe(typeof(double));
+            double.TryParse(sampleDouble, out _).ShouldBe(true);
 
             var sampleNumber = SampleData.GenerateSampleData("Number", null);
-            var numberValue = float.Parse(sampleNumber);
-            numberValue.GetType().ShouldBe(typeof(float));
+            double.TryParse(sampleNumber, out _).ShouldBe(true);
         }
 
         public void GeneratesProperStringSampleData()
         {
             var dateTimeString = SampleData.GenerateSampleData("string", "date-time");
             dateTimeString = dateTimeString.Replace("\"", "");
-            var sampleDateTime = DateTime.Parse(dateTimeString);
-            sampleDateTime.GetType().ShouldBe(typeof(DateTime));
+            DateTime.TryParse(dateTimeString, out _).ShouldBe(true);
 
             var sampleData = SampleData.GenerateSampleData("string", null);
             sampleData.GetType().ShouldBe(typeof(string));
@@ -128,8 +119,7 @@ namespace Totem.Tests.Features.API
             var guidString = SampleData.GenerateSampleData("string", null,
                 "^(([0-9a-f]){8}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){12})$");
             guidString = guidString.Replace("\"", "");
-            var sampleGuid = Guid.Parse(guidString);
-            sampleGuid.GetType().ShouldBe(typeof(Guid));
+            Guid.TryParse(guidString, out _).ShouldBe(true);
         }
 
         public void SampleDataHandlesInvalidPatternRegex()
@@ -196,8 +186,7 @@ namespace Totem.Tests.Features.API
             var items = JsonConvert.DeserializeObject<List<string>>(sampleData);
             foreach (var item in items)
             {
-                var parsedItem = int.Parse(item);
-                parsedItem.GetType().ShouldBe(typeof(int));
+                int.TryParse(item, out _).ShouldBe(true);
             }
         }
 
@@ -213,8 +202,7 @@ namespace Totem.Tests.Features.API
             var items = JsonConvert.DeserializeObject<List<string>>(sampleData);
             foreach (var item in items)
             {
-                var parsedItem = float.Parse(item);
-                parsedItem.GetType().ShouldBe(typeof(float));
+                float.TryParse(item, out _).ShouldBe(true);
             }
         }
 
@@ -231,8 +219,7 @@ namespace Totem.Tests.Features.API
             var items = JsonConvert.DeserializeObject<List<string>>(sampleData);
             foreach (var item in items)
             {
-                var parsedItem = DateTime.Parse(item);
-                parsedItem.GetType().ShouldBe(typeof(DateTime));
+                DateTime.TryParse(item, out _).ShouldBe(true);
             }
         }
 

--- a/src/Totem.Tests/Features/API/SampleDataTests.cs
+++ b/src/Totem.Tests/Features/API/SampleDataTests.cs
@@ -97,6 +97,21 @@ namespace Totem.Tests.Features.API
             intValue.GetType().ShouldBe(typeof(long));
         }
 
+        public void GeneratesProperNumberSampleData()
+        {
+            var sampleFloat = SampleData.GenerateSampleData("Number", "Float");
+            var floatValue = float.Parse(sampleFloat);
+            floatValue.GetType().ShouldBe(typeof(float));
+
+            var sampleDouble = SampleData.GenerateSampleData("Number", "Double");
+            var doubleValue = double.Parse(sampleDouble);
+            doubleValue.GetType().ShouldBe(typeof(double));
+
+            var sampleNumber = SampleData.GenerateSampleData("Number", null);
+            var numberValue = float.Parse(sampleNumber);
+            numberValue.GetType().ShouldBe(typeof(float));
+        }
+
         public void GeneratesProperStringSampleData()
         {
             var dateTimeString = SampleData.GenerateSampleData("string", "date-time");
@@ -183,6 +198,23 @@ namespace Totem.Tests.Features.API
             {
                 var parsedItem = int.Parse(item);
                 parsedItem.GetType().ShouldBe(typeof(int));
+            }
+        }
+
+        public void GeneratesProperNumberArraySampleData()
+        {
+            var arrayItem = new SchemaObject()
+            {
+                Type = "Number",
+                Format = "float"
+            };
+            var sampleData = SampleData.GenerateSampleData("array", null, items: arrayItem);
+
+            var items = JsonConvert.DeserializeObject<List<string>>(sampleData);
+            foreach (var item in items)
+            {
+                var parsedItem = float.Parse(item);
+                parsedItem.GetType().ShouldBe(typeof(float));
             }
         }
 

--- a/src/Totem.Tests/Features/Contracts/CreateTests.cs
+++ b/src/Totem.Tests/Features/Contracts/CreateTests.cs
@@ -1076,6 +1076,47 @@ namespace Totem.Tests.Features.Contracts
             command.ShouldNotValidate("The example 'not-an-integer-example' for 'Age' does not match the required data type or format 'integer'.");
         }
 
+        public void ShouldNotCreateWhenNonNumberTypeExampleForNumberType()
+        {
+            var newContract = SampleContract();
+            var command = new Create.Command()
+            {
+                Description = newContract.Description,
+                ContractString = @"{
+                    ""Contract"": {
+                        ""type"": ""object"",
+                        ""properties"": {
+                            ""Id"": {
+                                ""$ref"": ""#/Guid""
+                            },
+                            ""Timestamp"": {
+                                ""type"": ""string"",
+                                ""format"": ""date-time"",
+                                ""example"": ""2019-05-12T18:14:29Z""
+                            },
+                            ""Name"": {
+                                ""type"": ""string"",
+                                ""example"": ""John Doe""
+                            },
+                            ""Height"": {
+                                ""type"": ""number"",
+                                ""format"": ""float"",
+                                ""example"": ""not-a-number-example""
+                            }
+                        }
+                    },
+                    ""Guid"": {
+                        ""type"": ""string""
+                    }
+                }",
+                Namespace = newContract.Namespace,
+                Type = newContract.Type,
+                VersionNumber = newContract.VersionNumber
+            };
+
+            command.ShouldNotValidate("The example 'not-a-number-example' for 'Height' does not match the required data type or format 'number'.");
+        }
+
         public void ShouldNotCreateWhenNonDateTimeExampleForDateTimeFormat()
         {
             var newContract = SampleContract();

--- a/src/Totem.Tests/Features/Contracts/CreateTests.cs
+++ b/src/Totem.Tests/Features/Contracts/CreateTests.cs
@@ -18,7 +18,7 @@ namespace Totem.Tests.Features.Contracts
             var oldCount = CountRecords<Contract>();
             var newContract = SampleContract(true);
 
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = newContract.ContractString,
@@ -148,7 +148,7 @@ namespace Totem.Tests.Features.Contracts
             var oldCount = CountRecords<Contract>();
             var newContract = SampleContract(true);
 
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = newContract.ContractString,
@@ -187,7 +187,7 @@ namespace Totem.Tests.Features.Contracts
         {
             var newContract = SampleContract(true);
 
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = newContract.ContractString,
@@ -215,7 +215,7 @@ namespace Totem.Tests.Features.Contracts
         {
             var newContract = SampleContract(true);
 
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = newContract.ContractString,
@@ -232,7 +232,7 @@ namespace Totem.Tests.Features.Contracts
         {
             var newContract = SampleContract(true);
 
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = newContract.ContractString,
@@ -246,7 +246,7 @@ namespace Totem.Tests.Features.Contracts
 
         public void ShouldNotCreateWhenRequiredFieldsEmpty()
         {
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = "",
                 ContractString = "",
@@ -267,7 +267,7 @@ namespace Totem.Tests.Features.Contracts
         {
             var newContract = SampleContract(true);
 
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = @"{
@@ -314,7 +314,7 @@ namespace Totem.Tests.Features.Contracts
                     }
                 }";
 
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = newContract.ContractString,
@@ -338,7 +338,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenContractStringIsNotValidJson()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = "Not a valid JSON string",
@@ -353,7 +353,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenContractStringIsNotValidSchema()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = "{\"id\": \"Guid\", \"Timestamp\": \"DateTime\", \"Name\": \"String\", \"Age\": \"Int32\"}",
@@ -368,7 +368,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenContractStringTimestampDoesNotHaveFormat()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = @"{
@@ -443,7 +443,7 @@ namespace Totem.Tests.Features.Contracts
                     }
                 }";
 
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = newContract.ContractString,
@@ -510,7 +510,7 @@ namespace Totem.Tests.Features.Contracts
                     }
                 }";
 
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = newContract.ContractString,
@@ -583,7 +583,7 @@ namespace Totem.Tests.Features.Contracts
                     }
                 }";
 
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = newContract.ContractString,
@@ -652,7 +652,7 @@ namespace Totem.Tests.Features.Contracts
                     }
                 }";
 
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = newContract.ContractString,
@@ -676,7 +676,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenNestedArrayDoesNotHaveItems()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = @"{
@@ -730,7 +730,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenContractStringArrayDoesNotHaveItems()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = @"{
@@ -774,7 +774,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenContractStringArrayDoesNotHaveAValidItemsType()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = @"{
@@ -821,7 +821,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenNestedArrayDoesNotHaveAValidItemsType()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = @"{
@@ -878,7 +878,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenContractStringDoesNotHaveValidType()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = @"{
@@ -919,7 +919,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenContractStringDoesNotHaveValidFormat()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = @"{
@@ -960,7 +960,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenContractStringDoesNotHaveAProperFormat()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = @"{
@@ -1002,7 +1002,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenContractStringPropertyDoesNotHaveAType()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = @"{
@@ -1038,7 +1038,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenNonIntegerTypeExampleForIntegerType()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = @"{
@@ -1079,7 +1079,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenNonNumberTypeExampleForNumberType()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = @"{
@@ -1120,7 +1120,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenNonDateTimeExampleForDateTimeFormat()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = @"{
@@ -1161,7 +1161,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenNonGuidExampleForGuid()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = @"{
@@ -1206,7 +1206,7 @@ namespace Totem.Tests.Features.Contracts
         public void ShouldNotCreateWhenNestedExamplesDoNotMatchType()
         {
             var newContract = SampleContract();
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Description = newContract.Description,
                 ContractString = @"{
@@ -1257,7 +1257,7 @@ namespace Totem.Tests.Features.Contracts
             var initialContract = await AlreadyInDatabaseContract();
             var newContract = SampleContract(true);
 
-            var command = new Create.Command()
+            var command = new Create.Command
             {
                 Id = initialContract.Id,
                 Description = newContract.Description,

--- a/src/Totem.Tests/Features/Contracts/EditTests.cs
+++ b/src/Totem.Tests/Features/Contracts/EditTests.cs
@@ -222,7 +222,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldValidateDifferentFormsOfVersionNumber(string versionNumber)
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -232,7 +232,7 @@ namespace Totem.Tests.Features.Contracts
                 VersionNumber = initialContract.VersionNumber
             };
 
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -267,7 +267,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotValidateInvalidFormsOfVersionNumber(string versionNumber)
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -277,7 +277,7 @@ namespace Totem.Tests.Features.Contracts
                 VersionNumber = initialContract.VersionNumber
             };
 
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -351,7 +351,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenRequiredFieldsEmpty()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -361,7 +361,7 @@ namespace Totem.Tests.Features.Contracts
                 VersionNumber = initialContract.VersionNumber
             };
 
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = Guid.Empty,
                 Description = "",
@@ -388,7 +388,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenContractHasNoFields()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -398,7 +398,7 @@ namespace Totem.Tests.Features.Contracts
                 VersionNumber = initialContract.VersionNumber
             };
 
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -427,7 +427,7 @@ namespace Totem.Tests.Features.Contracts
             var initialContract = await AlreadyInDatabaseContract();
             var oldCount = CountRecords<Contract>();
 
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -456,7 +456,7 @@ namespace Totem.Tests.Features.Contracts
                         }
                     }
                 }";
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -489,7 +489,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenVersionIsNotValid()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -500,7 +500,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -522,7 +522,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenContractStringNotValidJson()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -533,7 +533,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -555,7 +555,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenContractStringNotValidSchema()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -566,7 +566,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -588,7 +588,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenContractStringTimestampDoesNotHaveFormat()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -599,7 +599,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -648,7 +648,7 @@ namespace Totem.Tests.Features.Contracts
             var initialContract = await AlreadyInDatabaseContract();
             var oldCount = CountRecords<Contract>();
 
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -692,7 +692,7 @@ namespace Totem.Tests.Features.Contracts
                         ""type"": ""string""
                     }
                 }";
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description, // Edited
@@ -727,7 +727,7 @@ namespace Totem.Tests.Features.Contracts
             var initialContract = await AlreadyInDatabaseContract();
             var oldCount = CountRecords<Contract>();
 
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -779,7 +779,7 @@ namespace Totem.Tests.Features.Contracts
                         ""type"": ""string""
                     }
                 }";
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description, // Edited
@@ -814,7 +814,7 @@ namespace Totem.Tests.Features.Contracts
             var initialContract = await AlreadyInDatabaseContract();
             var oldCount = CountRecords<Contract>();
 
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -872,7 +872,7 @@ namespace Totem.Tests.Features.Contracts
                         ""type"": ""string""
                     }
                 }";
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description, // Edited
@@ -907,7 +907,7 @@ namespace Totem.Tests.Features.Contracts
             var initialContract = await AlreadyInDatabaseContract();
             var oldCount = CountRecords<Contract>();
 
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -961,7 +961,7 @@ namespace Totem.Tests.Features.Contracts
                         ""type"": ""string""
                     }
                 }";
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description, // Edited
@@ -994,7 +994,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenContractStringArrayDoesNotHaveItems()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1005,7 +1005,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -1055,7 +1055,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenNestedArrayDoesNotHaveItems()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1066,7 +1066,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -1126,7 +1126,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenContractStringArrayDoesNotHaveAValidItemsType()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1137,7 +1137,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -1190,7 +1190,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenNestedArrayDoesNotHaveAValidItemsType()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1201,7 +1201,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -1264,7 +1264,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenContractStringDoesNotHaveValidType()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1275,7 +1275,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -1322,7 +1322,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenContractStringDoesNotHaveValidFormat()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1333,7 +1333,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -1380,7 +1380,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenContractStringDoesNotHaveAProperFormat()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1391,7 +1391,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -1439,7 +1439,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenContractStringPropertyDoesNotHaveAType()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1450,7 +1450,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -1492,7 +1492,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenNonIntegerTypeExampleForIntegerType()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1503,7 +1503,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -1551,7 +1551,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenNonNumberTypeExampleForNumberType()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1562,7 +1562,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -1610,7 +1610,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenNonDateTimeExampleForDateTimeFormat()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1621,7 +1621,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -1669,7 +1669,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenNonGuidExampleForGuid()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1680,7 +1680,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -1732,7 +1732,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenNestedExamplesDoNotMatchType()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1743,7 +1743,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description,
@@ -1799,7 +1799,7 @@ namespace Totem.Tests.Features.Contracts
         public async Task ShouldNotEditWhenVersionNumberExistOnAnotherContractWithSameId()
         {
             var initialContract = await AlreadyInDatabaseContract();
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1815,7 +1815,7 @@ namespace Totem.Tests.Features.Contracts
                 x.VersionNumber = "1.0.1";
             });
 
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1838,7 +1838,7 @@ namespace Totem.Tests.Features.Contracts
             var initialContract = await AlreadyInDatabaseContract();
             var oldCount = CountRecords<Contract>();
 
-            var initialContractModel = new Edit.EditModel()
+            var initialContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = initialContract.Description,
@@ -1850,7 +1850,7 @@ namespace Totem.Tests.Features.Contracts
             };
 
             var sampleContract = SampleContract();
-            var modifiedContractModel = new Edit.EditModel()
+            var modifiedContractModel = new Edit.EditModel
             {
                 Id = initialContract.Id,
                 Description = sampleContract.Description, // Edited

--- a/src/Totem.Tests/Features/Contracts/EditTests.cs
+++ b/src/Totem.Tests/Features/Contracts/EditTests.cs
@@ -1548,6 +1548,65 @@ namespace Totem.Tests.Features.Contracts
             command.ShouldNotValidate("The example 'not-an-integer-example' for 'Age' does not match the required data type or format 'integer'.");
         }
 
+        public async Task ShouldNotEditWhenNonNumberTypeExampleForNumberType()
+        {
+            var initialContract = await AlreadyInDatabaseContract();
+            var initialContractModel = new Edit.EditModel()
+            {
+                Id = initialContract.Id,
+                Description = initialContract.Description,
+                ContractString = initialContract.ContractString,
+                Namespace = initialContract.Namespace,
+                Type = initialContract.Type,
+                VersionNumber = initialContract.VersionNumber
+            };
+
+            var sampleContract = SampleContract();
+            var modifiedContractModel = new Edit.EditModel()
+            {
+                Id = initialContract.Id,
+                Description = sampleContract.Description,
+                ContractString = @"{
+                    ""Contract"": {
+                        ""type"": ""object"",
+                        ""properties"": {
+                            ""Id"": {
+                                ""$ref"": ""#/Guid""
+                            },
+                            ""Timestamp"": {
+                                ""type"": ""string"",
+                                ""format"": ""date-time"",
+                                ""example"": ""2019-05-12T18:14:29Z""
+                            },
+                            ""Name"": {
+                                ""type"": ""string"",
+                                ""example"": ""John Doe""
+                            },
+                            ""Height"": {
+                                ""type"": ""number"",
+                                ""format"": ""float"",
+                                ""example"": ""not-a-number-example""
+                            }
+                        }
+                    },
+                    ""Guid"": {
+                        ""type"": ""string""
+                    }
+                }",
+                Namespace = initialContract.Namespace,
+                Type = sampleContract.Type,
+                VersionNumber = sampleContract.VersionNumber
+            };
+
+            var command = new Edit.Command()
+            {
+                InitialContract = initialContractModel,
+                ModifiedContract = modifiedContractModel
+            };
+
+            command.ShouldNotValidate("The example 'not-a-number-example' for 'Height' does not match the required data type or format 'number'.");
+        }
+
         public async Task ShouldNotEditWhenNonDateTimeExampleForDateTimeFormat()
         {
             var initialContract = await AlreadyInDatabaseContract();

--- a/src/Totem.Tests/Services/TesterServiceTests.cs
+++ b/src/Totem.Tests/Services/TesterServiceTests.cs
@@ -375,10 +375,10 @@ namespace Totem.Tests.Services
             result.MessageErrors[0].ShouldBe("\"Array\" does not have the required property(Items) for type(Array).");
         }
 
-        [TestingConvention.Input("String")]
-        [TestingConvention.Input("Integer")]
-        [TestingConvention.Input("Number")]
-        public void ShouldFailValidationForArrayTypeWithIncorrectItemType(string dataType)
+        [Input("String", "not a datetime")]
+        [Input("Integer", "not an integer")]
+        [Input("Number", "not a number")]
+        public void ShouldFailValidationForArrayTypeWithIncorrectItemType(string dataType, string itemString)
         {
             var contractDictionary = new CaseInsensitiveDictionary<SchemaObject>
             {
@@ -392,20 +392,6 @@ namespace Totem.Tests.Services
                     }
                 }}
             };
-
-            var itemString = "";
-            switch (dataType)
-            {
-                case "String":
-                    itemString = "not a datetime"; // Not a string item
-                    break;
-                case "Integer":
-                    itemString = "not an integer"; // Not an integer item
-                    break;
-                case "Number":
-                    itemString = "not a number"; // Not a number item
-                    break;
-            }
 
             var messageKeyDictionary = new CaseInsensitiveDictionary<object>
             {

--- a/src/Totem.Tests/Services/TesterServiceTests.cs
+++ b/src/Totem.Tests/Services/TesterServiceTests.cs
@@ -260,6 +260,28 @@ namespace Totem.Tests.Services
             result.IsMessageValid.ShouldBeTrue();
         }
 
+        public void ShouldValidateNumberType()
+        {
+            var contractDictionary = new CaseInsensitiveDictionary<SchemaObject>
+            {
+                { "Number", new SchemaObject
+                {
+                    Type = "Number"
+                }}
+            };
+
+            var messageKeyDictionary = new CaseInsensitiveDictionary<object>
+            {
+                { "Number",  "4.5"}
+            };
+
+            var testerService = new TesterService();
+
+            var result = testerService.DoAllMessageValuesMatchDataTypes(messageKeyDictionary, contractDictionary);
+
+            result.IsMessageValid.ShouldBeTrue();
+        }
+
         public void ShouldFailValidationForNonIntegerType()
         {
             var contractDictionary = new CaseInsensitiveDictionary<SchemaObject>
@@ -280,6 +302,28 @@ namespace Totem.Tests.Services
             var result = testerService.DoAllMessageValuesMatchDataTypes(messageKeyDictionary, contractDictionary);
 
             result.IsMessageValid.ShouldBeFalse("\"Not an integer\" does not match the required data type for Integer (Integer).");
+        }
+
+        public void ShouldFailValidationForNonNumberType()
+        {
+            var contractDictionary = new CaseInsensitiveDictionary<SchemaObject>
+            {
+                { "Number", new SchemaObject
+                {
+                    Type = "Number"
+                }}
+            };
+
+            var messageKeyDictionary = new CaseInsensitiveDictionary<object>
+            {
+                { "Number",  "Not a number"}
+            };
+
+            var testerService = new TesterService();
+
+            var result = testerService.DoAllMessageValuesMatchDataTypes(messageKeyDictionary, contractDictionary);
+
+            result.IsMessageValid.ShouldBeFalse("\"Not a number\" does not match the required data type for Number (Number).");
         }
 
         public void ShouldValidateArrayType()
@@ -333,6 +377,7 @@ namespace Totem.Tests.Services
 
         [TestingConvention.Input("String")]
         [TestingConvention.Input("Integer")]
+        [TestingConvention.Input("Number")]
         public void ShouldFailValidationForArrayTypeWithIncorrectItemType(string dataType)
         {
             var contractDictionary = new CaseInsensitiveDictionary<SchemaObject>
@@ -355,7 +400,10 @@ namespace Totem.Tests.Services
                     itemString = "not a datetime"; // Not a string item
                     break;
                 case "Integer":
-                    itemString = "not an integer"; // Not an integer item 
+                    itemString = "not an integer"; // Not an integer item
+                    break;
+                case "Number":
+                    itemString = "not a number"; // Not a number item
                     break;
             }
 
@@ -472,6 +520,75 @@ namespace Totem.Tests.Services
             var result = testerService.DoAllMessageValuesMatchDataTypes(messageKeyDictionary, contractDictionary);
 
             result.IsMessageValid.ShouldBeFalse("\"2150000000\" does not match the required format for Integer (Int32).");
+        }
+
+        public void ShouldValidateFloatFormat()
+        {
+            var contractDictionary = new CaseInsensitiveDictionary<SchemaObject>
+            {
+                { "Number", new SchemaObject
+                {
+                    Type = "Number",
+                    Format = "float"
+                }}
+            };
+
+            var messageKeyDictionary = new CaseInsensitiveDictionary<object>
+            {
+                { "Number",  "5.7"}
+            };
+
+            var testerService = new TesterService();
+
+            var result = testerService.DoAllMessageValuesMatchDataTypes(messageKeyDictionary, contractDictionary);
+
+            result.IsMessageValid.ShouldBeTrue();
+        }
+
+        public void ShouldValidateDoubleFormat()
+        {
+            var contractDictionary = new CaseInsensitiveDictionary<SchemaObject>
+            {
+                { "Number", new SchemaObject
+                {
+                    Type = "Number",
+                    Format = "double"
+                }}
+            };
+
+            var messageKeyDictionary = new CaseInsensitiveDictionary<object>
+            {
+                { "Number",  "123456789012.34567"}
+            };
+
+            var testerService = new TesterService();
+
+            var result = testerService.DoAllMessageValuesMatchDataTypes(messageKeyDictionary, contractDictionary);
+
+            result.IsMessageValid.ShouldBeTrue();
+        }
+
+        public void ShouldFailValidationForNonFloatFormat()
+        {
+            var contractDictionary = new CaseInsensitiveDictionary<SchemaObject>
+            {
+                { "Number", new SchemaObject
+                {
+                    Type = "Number",
+                    Format = "float"
+                }}
+            };
+
+            var messageKeyDictionary = new CaseInsensitiveDictionary<object>
+            {
+                { "Number", double.MinValue}
+            };
+
+            var testerService = new TesterService();
+
+            var result = testerService.DoAllMessageValuesMatchDataTypes(messageKeyDictionary, contractDictionary);
+
+            result.IsMessageValid.ShouldBeFalse("\"123456789012.34567\" does not match the required format for Number (Float).");
         }
 
         public void ShouldValidateDateTimeFormat()

--- a/src/Totem/Features/API/SampleData.cs
+++ b/src/Totem/Features/API/SampleData.cs
@@ -129,6 +129,11 @@ namespace Totem.Features.API
                 return GenerateInteger(format);
             }
 
+            if (type.EqualsCaseInsensitive("number"))
+            {
+                return GenerateNumber(format);
+            }
+
             if (type.EqualsCaseInsensitive(DataType.Array.Value))
             {
                 if (items != null)
@@ -156,6 +161,10 @@ namespace Totem.Features.API
                     if (value.Type.EqualsCaseInsensitive("integer"))
                     {
                         _jsonDictionary[key] = GenerateInteger(value.Format);
+                    }
+                    if (value.Type.EqualsCaseInsensitive("number"))
+                    {
+                        _jsonDictionary[key] = GenerateNumber(value.Format);
                     }
                     if (value.Type.EqualsCaseInsensitive("string"))
                     {
@@ -202,6 +211,20 @@ namespace Totem.Features.API
             }
         }
 
+        public static string GenerateNumber(string format)
+        {
+            if (format != null && format.EqualsCaseInsensitive("Float"))
+            {
+                return "10.50";
+            }
+            if (format != null && format.EqualsCaseInsensitive("Double"))
+            {
+                return "123456789012.34567";
+            }
+
+            return "5.5"; // format not included or unknown
+        }
+
         public static string GenerateInteger(string format)
         {
             if (format != null && format.EqualsCaseInsensitive("Int32"))
@@ -225,6 +248,14 @@ namespace Totem.Features.API
                 for (var i = 0; i < length; i++)
                 {
                     returnArray.Add(GenerateInteger(itemFormat));
+                }
+            }
+
+            if (itemType.EqualsCaseInsensitive(DataType.Number.Value))
+            {
+                for (var i = 0; i < length; i++)
+                {
+                    returnArray.Add(GenerateNumber(itemFormat));
                 }
             }
 

--- a/src/Totem/Features/API/SampleData.cs
+++ b/src/Totem/Features/API/SampleData.cs
@@ -124,12 +124,12 @@ namespace Totem.Features.API
 
         public static string GenerateSampleData(string type, string format, string pattern = null, CaseInsensitiveDictionary<SchemaObject> properties = null, SchemaObject items = null, int minItems = 0, int maxItems = 0)
         {
-            if (type.EqualsCaseInsensitive("integer"))
+            if (type.EqualsCaseInsensitive(DataType.Integer.Value))
             {
                 return GenerateInteger(format);
             }
 
-            if (type.EqualsCaseInsensitive("number"))
+            if (type.EqualsCaseInsensitive(DataType.Number.Value))
             {
                 return GenerateNumber(format);
             }
@@ -141,7 +141,7 @@ namespace Totem.Features.API
                 return "[]";
             }
 
-            if (type.EqualsCaseInsensitive("object"))
+            if (type.EqualsCaseInsensitive(DataType.Object.Value))
             {
                 // Replace quotes inside nested JSON objects and remove slashes
                 return GenerateObject(properties).Replace(@"\", "").Replace("\"{", "{").Replace("}\"", "}");
@@ -158,20 +158,20 @@ namespace Totem.Features.API
             {
                 foreach (var (key, value) in properties)
                 {
-                    if (value.Type.EqualsCaseInsensitive("integer"))
+                    if (value.Type.EqualsCaseInsensitive(DataType.Integer.Value))
                     {
                         _jsonDictionary[key] = GenerateInteger(value.Format);
                     }
-                    if (value.Type.EqualsCaseInsensitive("number"))
+                    if (value.Type.EqualsCaseInsensitive(DataType.Number.Value))
                     {
                         _jsonDictionary[key] = GenerateNumber(value.Format);
                     }
-                    if (value.Type.EqualsCaseInsensitive("string"))
+                    if (value.Type.EqualsCaseInsensitive(DataType.String.Value))
                     {
                         //Removing extra quotes from string examples in nested objects
                         _jsonDictionary[key] = GenerateString(value.Format, value.Pattern).Replace("\"", ""); ;
                     }
-                    if (value.Type.EqualsCaseInsensitive("object"))
+                    if (value.Type.EqualsCaseInsensitive(DataType.Object.Value))
                     {
                         _jsonDictionary[key] = GenerateObject(value.Properties);
                     }
@@ -191,7 +191,7 @@ namespace Totem.Features.API
 
         public static string GenerateString(string format, string pattern)
         {
-            if (format != null && format.EqualsCaseInsensitive("date-time"))
+            if (format != null && format.EqualsCaseInsensitive(Format.DateTime.Value))
             {
                 var currentDate = DateTime.Now;
                 return $"\"{currentDate.ToString("s", CultureInfo.InvariantCulture)}\"";
@@ -213,11 +213,11 @@ namespace Totem.Features.API
 
         public static string GenerateNumber(string format)
         {
-            if (format != null && format.EqualsCaseInsensitive("Float"))
+            if (format != null && format.EqualsCaseInsensitive(Format.Float.Value))
             {
                 return "10.50";
             }
-            if (format != null && format.EqualsCaseInsensitive("Double"))
+            if (format != null && format.EqualsCaseInsensitive(Format.Double.Value))
             {
                 return "123456789012.34567";
             }
@@ -227,11 +227,11 @@ namespace Totem.Features.API
 
         public static string GenerateInteger(string format)
         {
-            if (format != null && format.EqualsCaseInsensitive("Int32"))
+            if (format != null && format.EqualsCaseInsensitive(Format.Int32.Value))
             {
                 return "5";
             }
-            if (format != null && format.EqualsCaseInsensitive("Int64"))
+            if (format != null && format.EqualsCaseInsensitive(Format.Int64.Value))
             {
                 return "2147483650";
             }

--- a/src/Totem/Features/Shared/ValidationExtensions.cs
+++ b/src/Totem/Features/Shared/ValidationExtensions.cs
@@ -179,6 +179,16 @@ namespace Totem.Features.Shared
                     }
                 }
 
+                if (type.EqualsCaseInsensitive(DataType.Number.Value))
+                {
+                    var isExampleNumber = double.TryParse(example, out _) || float.TryParse(example, out _);
+                    // Validate example is number data type
+                    if (!isExampleNumber)
+                    {
+                        AddExampleError(context, example, propertyName, type);
+                    }
+                }
+
                 if (type.EqualsCaseInsensitive(DataType.String.Value))
                 {
                     // Validate  example is date-time data type

--- a/src/Totem/Services/TesterService.cs
+++ b/src/Totem/Services/TesterService.cs
@@ -152,6 +152,11 @@ namespace Totem.Services
                 CheckIntegerType(propertySchemaObject, kv, testMessageResult);
             }
 
+            if (propertySchemaObject.Type.EqualsCaseInsensitive(DataType.Number.Value))
+            {
+                CheckNumberType(propertySchemaObject, kv, testMessageResult);
+            }
+
             if (propertySchemaObject.Type.EqualsCaseInsensitive(DataType.String.Value))
             {
                 CheckStringType(propertySchemaObject, kv, testMessageResult);
@@ -190,6 +195,32 @@ namespace Totem.Services
                 else if (propertySchemaObject.Format.EqualsCaseInsensitive("int64") && !isInt64)
                 {
                     AddFormatError(testMessageResult, kv.Value.ToString(), kv.Key, "Int64");
+                }
+            }
+        }
+
+        private static void CheckNumberType(SchemaObject propertySchemaObject, KeyValuePair<string, object> kv,
+            TestMessageResult testMessageResult)
+        {
+            var isDouble = double.TryParse(kv.Value.ToString(), out _);
+            var isFloat = float.TryParse(kv.Value.ToString(), out _);
+            
+            // Validate number data type
+            if (!isDouble && !isFloat)
+            {
+                AddTypeError(testMessageResult, kv.Value.ToString(), kv.Key, propertySchemaObject.Type);
+            }
+
+            if (propertySchemaObject.Format != null)
+            {
+                // Validate specific number formats
+                if (propertySchemaObject.Format.EqualsCaseInsensitive("float") && !isFloat)
+                {
+                    AddFormatError(testMessageResult, kv.Value.ToString(), kv.Key, "Float");
+                }
+                else if (propertySchemaObject.Format.EqualsCaseInsensitive("double") && !isDouble)
+                {
+                    AddFormatError(testMessageResult, kv.Value.ToString(), kv.Key, "Double");
                 }
             }
         }
@@ -260,6 +291,14 @@ namespace Totem.Services
                     if (!TryParseIntegerArray(itemArray))
                     {
                         AddItemTypeError(testMessageResult, kv.Key, DataType.Integer.Value);
+                    }
+                }
+
+                if (itemSchema.Type.EqualsCaseInsensitive(DataType.Number.Value))
+                {
+                    if (!TryParseNumberArray(itemArray))
+                    {
+                        AddItemTypeError(testMessageResult, kv.Key, DataType.Number.Value);
                     }
                 }
             }
@@ -386,6 +425,21 @@ namespace Totem.Services
                 int notInt32;
                 long notInt64;
                 if ((!int.TryParse(item.ToString(), out notInt32)) || (!long.TryParse(item.ToString(), out notInt64)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool TryParseNumberArray(dynamic itemArray)
+        {
+            foreach (var item in itemArray)
+            {
+                float notFloat;
+                double notDouble;
+                if ((!float.TryParse(item.ToString(), out notFloat)) || (!double.TryParse(item.ToString(), out notDouble)))
                 {
                     return false;
                 }


### PR DESCRIPTION
- Added an up script to add numbers and number formats to the ContractSchema table.
- Added methods to support numbers and formats similar to integers in ValidationExtensions and TesterService.
- Added support for numbers and number arrays in SampleData.
- Added unit tests to support number, number formats and number arrays across SampleData, Create/Edit and TesterService.