### PR TITLE
Feature/#76 allow extra fields in test messages

### DIFF
--- a/src/Totem.Tests/Features/API/TestMessageTests.cs
+++ b/src/Totem.Tests/Features/API/TestMessageTests.cs
@@ -454,6 +454,11 @@ namespace Totem.Tests.Features.API
                 "Message is missing expected property \"Name\".",
                 "Message is missing expected property \"Timestamp\"."
             });
+
+            result.Warnings.ShouldBe(new List<string>
+            {
+                "Message property \"FirstName\" is not part of the contract."
+            });
         }
 
         public async Task ShouldBeInvalidWhenMessageIsInvalidWithFutureDeprecationDate()
@@ -481,6 +486,11 @@ namespace Totem.Tests.Features.API
                 "Message is missing expected property \"Id\".",
                 "Message is missing expected property \"Name\".",
                 "Message is missing expected property \"Timestamp\"."
+            });
+
+            result.Warnings.ShouldBe(new List<string>
+            {
+                "Message property \"FirstName\" is not part of the contract."
             });
         }
     }

--- a/src/Totem.Tests/Features/API/TestMessageTests.cs
+++ b/src/Totem.Tests/Features/API/TestMessageTests.cs
@@ -450,11 +450,9 @@ namespace Totem.Tests.Features.API
             result.IsValid.ShouldBeFalse();
             result.MessageErrors.ShouldBe(new List<string>
             {
-                "Message property \"FirstName\" is not part of the contract.",
                 "Message is missing expected property \"Id\".",
                 "Message is missing expected property \"Name\".",
-                "Message is missing expected property \"Timestamp\".",
-                "The schema for \"FirstName\" was not found in the contract definition."
+                "Message is missing expected property \"Timestamp\"."
             });
         }
 
@@ -480,11 +478,9 @@ namespace Totem.Tests.Features.API
             result.WarningMessage.ShouldBe($"This contract will be deprecated on {DateTime.Today.AddDays(5)}, please check for a new version.");
             result.MessageErrors.ShouldBe(new List<string>
             {
-                "Message property \"FirstName\" is not part of the contract.",
                 "Message is missing expected property \"Id\".",
                 "Message is missing expected property \"Name\".",
-                "Message is missing expected property \"Timestamp\".",
-                "The schema for \"FirstName\" was not found in the contract definition."
+                "Message is missing expected property \"Timestamp\"."
             });
         }
     }

--- a/src/Totem.Tests/Features/Contracts/TestMessageTests.cs
+++ b/src/Totem.Tests/Features/Contracts/TestMessageTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Fixie.Internal;
 using Shouldly;
 using Totem.Features.Contracts;
 using static Totem.Tests.Testing;
@@ -528,11 +527,16 @@ namespace Totem.Tests.Features.Contracts
             var result = await Send(command);
 
             result.IsValid.ShouldBeFalse();
-            result.MessageErrors.ShouldBe(new List<string>()
+            result.MessageErrors.ShouldBe(new List<string>
             {
                 "Message is missing expected property \"Id\".",
                 "Message is missing expected property \"Name\".",
                 "Message is missing expected property \"Timestamp\"."
+            });
+
+            result.Warnings.ShouldBe(new List<string>
+            {
+                "Message property \"FirstName\" is not part of the contract."
             });
         }
 
@@ -569,6 +573,11 @@ namespace Totem.Tests.Features.Contracts
                 "Message is missing expected property \"Id\".",
                 "Message is missing expected property \"Name\".",
                 "Message is missing expected property \"Timestamp\"."
+            });
+
+            result.Warnings.ShouldBe(new List<string>
+            {
+                "Message property \"FirstName\" is not part of the contract."
             });
         }
     }

--- a/src/Totem.Tests/Features/Contracts/TestMessageTests.cs
+++ b/src/Totem.Tests/Features/Contracts/TestMessageTests.cs
@@ -65,7 +65,7 @@ namespace Totem.Tests.Features.Contracts
             var result = await Send(command);
 
             result.IsValid.ShouldBeTrue();
-            result.WarningMessage.ShouldBe($"This contract will be deprecated on {DateTime.Today.AddDays(5)}, please check for a new version.");
+            result.DeprecationWarningMessage.ShouldBe($"This contract will be deprecated on {DateTime.Today.AddDays(5)}, please check for a new version.");
             result.MessageErrors.ShouldBeEmpty();
         }
 
@@ -530,11 +530,9 @@ namespace Totem.Tests.Features.Contracts
             result.IsValid.ShouldBeFalse();
             result.MessageErrors.ShouldBe(new List<string>()
             {
-                "Message property \"FirstName\" is not part of the contract.",
                 "Message is missing expected property \"Id\".",
                 "Message is missing expected property \"Name\".",
-                "Message is missing expected property \"Timestamp\".",
-                "The schema for \"FirstName\" was not found in the contract definition."
+                "Message is missing expected property \"Timestamp\"."
             });
         }
 
@@ -565,14 +563,12 @@ namespace Totem.Tests.Features.Contracts
             var result = await Send(command);
 
             result.IsValid.ShouldBeFalse();
-            result.WarningMessage.ShouldBe($"This contract will be deprecated on {DateTime.Today.AddDays(5)}, please check for a new version.");
+            result.DeprecationWarningMessage.ShouldBe($"This contract will be deprecated on {DateTime.Today.AddDays(5)}, please check for a new version.");
             result.MessageErrors.ShouldBe(new List<string>
             {
-                "Message property \"FirstName\" is not part of the contract.",
                 "Message is missing expected property \"Id\".",
                 "Message is missing expected property \"Name\".",
-                "Message is missing expected property \"Timestamp\".",
-                "The schema for \"FirstName\" was not found in the contract definition."
+                "Message is missing expected property \"Timestamp\"."
             });
         }
     }

--- a/src/Totem.Tests/Services/TesterServiceTests.cs
+++ b/src/Totem.Tests/Services/TesterServiceTests.cs
@@ -169,7 +169,7 @@ namespace Totem.Tests.Services
             result.IsMessageValid.ShouldBeTrue();
         }
 
-        public void AreAllElementsInMessageContainedInContractShouldReturnInvalidContract()
+        public void AreAllElementsInMessageContainedInContractShouldReturnValidContractWithWarnings()
         {
             var contractDictionary = new CaseInsensitiveDictionary<SchemaObject>
             {
@@ -188,8 +188,8 @@ namespace Totem.Tests.Services
             var testService = new TesterService();
 
             var result = testService.AreAllElementsInMessageContainedInContract(messageKeyDictionary, contractDictionary);
-
-            result.IsMessageValid.ShouldBeFalse("Message property \"Age\" is not part of the contract.");
+            result.IsMessageValid.ShouldBeTrue();
+            result.Warnings[0].ShouldBe("Message property \"Age\" is not part of the contract.");
         }
 
         public void AreAllElementsCorrectDataTypeShouldReturnValidContract()
@@ -742,7 +742,7 @@ namespace Totem.Tests.Services
             result.MessageErrors[0].ShouldBe("\"not an object\" does not match the required data type for Object (Object).");
         }
 
-        public void ShouldFailValidationIfSchemaNotFound()
+        public void ShouldNotFailValidationIfSchemaNotFound()
         {
             var contractDictionary = new CaseInsensitiveDictionary<SchemaObject>
             {
@@ -761,8 +761,7 @@ namespace Totem.Tests.Services
 
             var result = testerService.DoAllMessageValuesMatchDataTypes(messageKeyDictionary, contractDictionary);
 
-            result.IsMessageValid.ShouldBeFalse();
-            result.MessageErrors[0].ShouldBe("The schema for \"LastName\" was not found in the contract definition.");
+            result.IsMessageValid.ShouldBeTrue();
         }
 
         public void ShouldFailValidationWhenMissingNestedProperty()

--- a/src/Totem/Features/API/TestMessage.cs
+++ b/src/Totem/Features/API/TestMessage.cs
@@ -68,6 +68,7 @@ namespace Totem.Features.API
                     }
 
                     result.MessageErrors = testResult.MessageErrors;
+                    result.Warnings = testResult.Warnings;
                 }
 
                 result.IsValid = isValid;
@@ -97,6 +98,7 @@ namespace Totem.Features.API
             public string WarningMessage { get; set; }
             public bool IsValid { get; set; }
             public List<string> MessageErrors { get; set; } = new List<string>();
+            public List<string> Warnings { get; set; } = new List<string>();
         }
     }
 }

--- a/src/Totem/Features/Contracts/MappingProfile.cs
+++ b/src/Totem/Features/Contracts/MappingProfile.cs
@@ -30,9 +30,10 @@ namespace Totem.Features.Contracts
                 .ForMember(x => x.ContractId, opt => opt.MapFrom(x => x.Id))
                 .ForMember(x => x.ContractDescription, opt => opt.MapFrom(x => x.Description))
                 .ForMember(x => x.MessageErrors, opt => opt.Ignore())
+                .ForMember(x => x.Warnings, opt => opt.Ignore())
                 .ForMember(x => x.TestMessage, opt => opt.Ignore())
                 .ForMember(x => x.IsValid, opt => opt.Ignore())
-                .ForMember(x => x.WarningMessage, opt => opt.Ignore())
+                .ForMember(x => x.DeprecationWarningMessage, opt => opt.Ignore())
                 .ForMember(x => x.ContractObject, opt => opt.MapFrom(x => SchemaObject.BuildSchemaDictionary(x.ContractString, NoOp, NoOp)));
 
             CreateMap<Contract, Index.ViewModel>()

--- a/src/Totem/Features/Contracts/TestMessage.cs
+++ b/src/Totem/Features/Contracts/TestMessage.cs
@@ -94,11 +94,10 @@ namespace Totem.Features.Contracts
                     {
                         isValid = false;
                     }
-
                     result.MessageErrors = testResult.MessageErrors;
+                    result.Warnings = testResult.Warnings;
                 }
-
-                result.WarningMessage = warningMessage;
+                result.DeprecationWarningMessage = warningMessage;
                 result.IsValid = isValid;
                 return result;
             }
@@ -115,10 +114,11 @@ namespace Totem.Features.Contracts
             [DisplayName("Properties")]
             public CaseInsensitiveDictionary<SchemaObject> ContractObject { get; set; }
             public string ContractString { get; set; }
-            public string WarningMessage { get; set; }
+            public string DeprecationWarningMessage { get; set; }
             public string TestMessage { get; set; }
             public bool IsValid { get; set; }
             public IList<string> MessageErrors { get; set; } = new List<string>();
+            public IList<string> Warnings { get; set; } = new List<string>();
         }
     }
 }

--- a/src/Totem/Features/Contracts/TestMessage.cshtml
+++ b/src/Totem/Features/Contracts/TestMessage.cshtml
@@ -1,4 +1,4 @@
-﻿@using Totem.Features.Contracts
+@using Totem.Features.Contracts
 @model TestMessage.ViewModel
 @inject SignInManager<IdentityUser> SignInManager
 
@@ -58,11 +58,25 @@
                 {
                     if (Model.IsValid)
                     {
-                        <h4 class="result-message success">Message is Valid. @Model.WarningMessage</h4>
+                        <h4 class="result-message success">Message is Valid.</h4>
+                        <div class="result-message warning">
+                            @Model.DeprecationWarningMessage
+                            @foreach (var item in Model.Warnings)
+                            {
+                                <div>@item</div>
+                            }
+                        </div>
                     }
                     else
                     {
-                        <h4 class="result-message error">Message is Invalid. @Model.WarningMessage</h4>
+                        <h4 class="result-message error">Message is Invalid. </h4>
+                        <div class="result-message warning">
+                            @Model.DeprecationWarningMessage
+                            @foreach (var item in Model.Warnings)
+                            {
+                                <div>@item</div>
+                            }
+                        </div>
                         <div class="result-message error">
                             @foreach (var item in Model.MessageErrors)
                             {

--- a/src/Totem/Services/TesterService.cs
+++ b/src/Totem/Services/TesterService.cs
@@ -63,6 +63,7 @@ namespace Totem.Services
             return new TestMessageResult
             {
                 IsMessageValid = TestCases.All(x => x.IsMessageValid),
+                Warnings = TestCases.SelectMany(x => x.Warnings).ToList(),
                 MessageErrors = TestCases.SelectMany(x => x.MessageErrors).ToList()
             };
         }
@@ -99,8 +100,8 @@ namespace Totem.Services
             {
                 if (contractDictionary.Keys.Contains(kv.Key, StringComparer.InvariantCultureIgnoreCase)) continue;
 
-                result.IsMessageValid = false;
-                result.MessageErrors.Add($"Message property \"{kv.Key}\" is not part of the contract.");
+                result.IsMessageValid = true;
+                result.Warnings.Add($"Message property \"{kv.Key}\" is not part of the contract.");
             }
 
             return result;
@@ -134,10 +135,6 @@ namespace Totem.Services
                 if (propertySchemaObject != null)
                 {
                     ChecksForMessage(propertySchemaObject, kv, testMessageResult);
-                }
-                else
-                {
-                    AddSchemaNotFoundError(testMessageResult, kv.Key);
                 }
             }
 
@@ -504,6 +501,7 @@ namespace Totem.Services
         {
             public bool IsMessageValid { get; set; } = true;
             public List<string> MessageErrors { get; set; } = new List<string>();
+            public List<string> Warnings { get; set; } = new List<string>();
         }
     }
 }

--- a/src/Totem/Services/TesterService.cs
+++ b/src/Totem/Services/TesterService.cs
@@ -377,13 +377,6 @@ namespace Totem.Services
                 $"The value for field \"{property}\" was not found.");
         }
 
-        private static void AddSchemaNotFoundError(TestMessageResult result, string property)
-        {
-            result.IsMessageValid = false;
-            result.MessageErrors.Add(
-                $"The schema for \"{property}\" was not found in the contract definition.");
-        }
-
         private static void AddRequiredError(TestMessageResult result, string key, string type, string requiredProperty)
         {
             result.IsMessageValid = false;

--- a/src/Totem/wwwroot/css/site.css
+++ b/src/Totem/wwwroot/css/site.css
@@ -76,6 +76,10 @@ textarea.tall {
   color: #f00;
 }
 
+.result-message.warning {
+  color: #F09D51;
+}
+
 .row-actions {
   max-width: 340px;
 }


### PR DESCRIPTION
- Set IsMessageValid to true when all message fields are not present in the contract. Added Warnings list to the TestMessageResult to keep track of the warnings.
- Renamed WarningMessage to DeprecationWarningMessage. Added a Warnings list to keep track of the warnings and display on the page. Added Warnings to the MappingProfile. Added a css style for warning messages.
- Refactored tests to allow extra fields in the message which are not present in the contract.